### PR TITLE
Supply required PortfolioId in product parameters

### DIFF
--- a/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "develop/sc-portfolio-ec2.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "develop/sc-portfolio-ec2.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/develop/sc-product-ec2-linux-jumpcloud.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "develop/sc-portfolio-ec2.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "develop/sc-portfolio-ec2.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/develop/sc-product-s3-private-enc.yaml
+++ b/config/develop/sc-product-s3-private-enc.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "develop/sc-portfolio-s3-basic.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/develop/sc-product-s3-synapse.yaml
+++ b/config/develop/sc-product-s3-synapse.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "develop/sc-portfolio-s3-basic.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-ec2.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-ec2.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-ec2.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/prod/sc-product-s3-private-enc.yaml
+++ b/config/prod/sc-product-s3-private-enc.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-s3-basic.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:

--- a/config/prod/sc-product-s3-synapse.yaml
+++ b/config/prod/sc-product-s3-synapse.yaml
@@ -7,6 +7,7 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-s3-basic.yaml"
 parameters:
+  PortfolioId: !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
 hooks:


### PR DESCRIPTION
Adds the portfolios ids that are required when configuring a product stack. This PR is dependent upon Sage-Bionetworks/service-catalog-library#143.