### PR TITLE
Update reference to custom resource

### DIFF
--- a/config/develop/cfn-sc-actions-provider.yaml
+++ b/config/develop/cfn-sc-actions-provider.yaml
@@ -1,4 +1,4 @@
-template_path: remote/cfn-sc-actions-provider.yaml
+template_path: remote/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-sc-actions-provider
 stack_tags:
   Department: "Platform"
@@ -8,4 +8,4 @@ dependencies:
   - develop/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cfn-sc-actions-provider.yaml --create-dirs -o templates/remote/cfn-sc-actions-provider.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml --create-dirs -o templates/remote/cfn-cr-sc-actions-provider.yaml"

--- a/config/prod/cfn-sc-actions-provider.yaml
+++ b/config/prod/cfn-sc-actions-provider.yaml
@@ -1,4 +1,4 @@
-template_path: remote/cfn-sc-actions-provider.yaml
+template_path: remote/cfn-cr-sc-actions-provider.yaml
 stack_name: cfn-sc-actions-provider
 stack_tags:
   Department: "Platform"
@@ -8,4 +8,4 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cfn-sc-actions-provider.yaml --create-dirs -o templates/remote/cfn-sc-actions-provider.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/cfn-cr-sc-actions-provider/master/cfn-cr-sc-actions-provider.yaml --create-dirs -o templates/remote/cfn-cr-sc-actions-provider.yaml"


### PR DESCRIPTION
The cfn-sc-actions-provider moved and now deploys to a different bucket
path so we need to update the reference to the new location.

The custom resource moved to
https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-actions-provider

There was a bug in the underlying lambda build,  it's fixed with PR
https://github.com/Sage-Bionetworks-IT/cfn-cr-sc-actions-provider/pull/2

This build depends on that PR.