### PR TITLE
Build new policy stack in SC

### DIFF
--- a/config/develop/get-role-policy.yaml
+++ b/config/develop/get-role-policy.yaml
@@ -1,0 +1,7 @@
+template_path: "remote/iam/get-role-policy.yaml"
+stack_name: "get-role-policy"
+hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"

--- a/config/develop/sc-remoting-policy.yaml
+++ b/config/develop/sc-remoting-policy.yaml
@@ -1,7 +1,0 @@
-template_path: "remote/iam/sc-remoting-policy.yaml"
-stack_name: "sc-remoting-policy"
-hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-remoting-policy.yaml --create-dirs -o templates/remote/sc-remoting-policy.yaml"
-  before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-remoting-policy.yaml --create-dirs -o templates/remote/sc-remoting-policy.yaml"

--- a/config/develop/sc-remoting-policy.yaml
+++ b/config/develop/sc-remoting-policy.yaml
@@ -1,0 +1,7 @@
+template_path: "remote/iam/sc-remoting-policy.yaml"
+stack_name: "sc-remoting-policy"
+hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-remoting-policy.yaml --create-dirs -o templates/remote/sc-remoting-policy.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/sc-remoting-policy.yaml --create-dirs -o templates/remote/sc-remoting-policy.yaml"


### PR DESCRIPTION
This adds a new stack to the Service Catalog for remote access policies used when creating instances. I plan to revise tagging policies and include them in this stack rather than what we use in essentials.

Passes pre-commit
Related to https://github.com/Sage-Bionetworks/service-catalog-library/pull/150