### PR TITLE
Fix remote path in hook

### DIFF
--- a/config/develop/get-role-policy.yaml
+++ b/config/develop/get-role-policy.yaml
@@ -2,6 +2,6 @@ template_path: "remote/iam/get-role-policy.yaml"
 stack_name: "get-role-policy"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/iam/get-role-policy.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/iam/get-role-policy.yaml"


### PR DESCRIPTION
The path in the sceptre hooks was wrong. This should resolve the Travis deployment error.
