### PR TITLE
SC 54.4 Match template path with output of hook

### DIFF
--- a/config/develop/get-role-policy.yaml
+++ b/config/develop/get-role-policy.yaml
@@ -1,7 +1,7 @@
-template_path: "remote/iam/get-role-policy.yaml"
+template_path: "remote/get-role-policy.yaml"
 stack_name: "get-role-policy"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/iam/get-role-policy.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/iam/get-role-policy.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"

--- a/config/develop/get-role-policy.yaml
+++ b/config/develop/get-role-policy.yaml
@@ -2,6 +2,6 @@ template_path: "remote/iam/get-role-policy.yaml"
 stack_name: "get-role-policy"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/iam/get-role-policy.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/iam/get-role-policy.yaml"


### PR DESCRIPTION
This PR should fix the resolution error that causes the Travis deploy step to fail. The template_path variable did not match that curl command output. Maybe there's a way to have sceptre do that substitution?