### PR TITLE
Add maintenance task to devel

### DIFF
--- a/config/develop/maintenance.yaml
+++ b/config/develop/maintenance.yaml
@@ -1,0 +1,9 @@
+template_path: remote/maintenance.yaml
+stack_name: prod-default-maintenance-window
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/maintenance.yaml --create-dirs -o templates/remote/maintenance.yaml"


### PR DESCRIPTION
This adds a scheduled task to the develop account based on the template from aws-infra.

Related: https://github.com/Sage-Bionetworks/aws-infra/pull/244