### PR TITLE
Workaround to update dependent templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ jobs:
     - stage: deploy
       script:
         - sceptre --debug delete $TRAVIS_BRANCH/sc-product-assoc-ec2 --yes
+        - sceptre --debug delete $TRAVIS_BRANCH/sc-product-ec2 --yes
         - sceptre --debug launch $TRAVIS_BRANCH --yes


### PR DESCRIPTION
The AWS::ServiceCatalog::CloudFormationProduct resource is not updating
templates referenced by LoadTemplateFromURL property.  This is a
work around for that.  We need to delete and re-install the product
on every build.