### PR TITLE
Remove StackDatetime from product stack configurations

### DIFF
--- a/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -10,7 +10,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud-notebook.yaml"

--- a/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -10,7 +10,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud-workflows.yaml"

--- a/config/develop/sc-product-ec2-linux-jumpcloud.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud.yaml
@@ -10,7 +10,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud.yaml"

--- a/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -10,7 +10,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-windows-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-windows-jumpcloud.yaml"

--- a/config/develop/sc-product-s3-private-enc.yaml
+++ b/config/develop/sc-product-s3-private-enc.yaml
@@ -9,7 +9,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/s3/sc-product-s3-private-enc.yaml --create-dirs -o templates/remote/sc-product-s3-private-enc.yaml"

--- a/config/develop/sc-product-s3-synapse.yaml
+++ b/config/develop/sc-product-s3-synapse.yaml
@@ -9,7 +9,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/s3/sc-product-s3-synapse.yaml --create-dirs -o templates/remote/sc-product-s3-synapse.yaml"

--- a/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -9,7 +9,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud-notebook.yaml"

--- a/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -9,7 +9,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud-workflows.yaml"

--- a/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -9,7 +9,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud.yaml"

--- a/config/prod/sc-product-ec2-windows-jumpcloud.yaml
+++ b/config/prod/sc-product-ec2-windows-jumpcloud.yaml
@@ -9,7 +9,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-windows-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-windows-jumpcloud.yaml"

--- a/config/prod/sc-product-s3-private-enc.yaml
+++ b/config/prod/sc-product-s3-private-enc.yaml
@@ -9,7 +9,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/s3/sc-product-s3-private-enc.yaml --create-dirs -o templates/remote/sc-product-s3-private-enc.yaml"

--- a/config/prod/sc-product-s3-synapse.yaml
+++ b/config/prod/sc-product-s3-synapse.yaml
@@ -9,7 +9,6 @@ dependencies:
 parameters:
   PortfolioId: !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/s3/sc-product-s3-synapse.yaml --create-dirs -o templates/remote/sc-product-s3-synapse.yaml"


### PR DESCRIPTION
Removes the date param that was previously used to ensure product versions updated.
This PR should be merged prior to https://github.com/Sage-Bionetworks/service-catalog-library/pull/165.