### PR TITLE
Add get-role-policy template to prod path

### DIFF
--- a/config/prod/get-role-policy.yaml
+++ b/config/prod/get-role-policy.yaml
@@ -1,0 +1,7 @@
+template_path: "remote/get-role-policy.yaml"
+stack_name: "get-role-policy"
+hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/iam/get-role-policy.yaml --create-dirs -o templates/remote/get-role-policy.yaml"


### PR DESCRIPTION
The region-get-role-policy-ReadAssumedRoleInformationPolicy export is missing from cfn in scipoolprod. See [SC-157](https://sagebionetworks.jira.com/projects/SC/issues/SC-157)

Will need to merge develop->prod after.

Passes pre-commit.