### PR TITLE
turn off sceptre debug logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ jobs:
         - pre-commit run --all-files
     - stage: deploy
       script:
-        - sceptre --debug delete $TRAVIS_BRANCH/sc-product-assoc-ec2 --yes
-        - sceptre --debug launch $TRAVIS_BRANCH --yes
+        - sceptre delete $TRAVIS_BRANCH/sc-product-assoc-ec2 --yes
+        - sceptre launch $TRAVIS_BRANCH --yes


### PR DESCRIPTION
Sceptre debug is too noisy and it's error messages are not that helpful.
Goting back to non debug log is actually more helpful.