### PR TITLE
[SC-171] Make SC service actions sticky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ install:
   - pip install pre-commit sceptre sceptre-ssm-resolver sceptre-date-resolver
 stages:
   - name: validate
+  - name: disassociate-sc-actions
+    if: type = push AND branch = develop
   - name: deploy
     if: type = push
 jobs:
@@ -21,7 +23,9 @@ jobs:
       script:
         - pre-commit autoupdate
         - pre-commit run --all-files
-    - stage: deploy
+    - stage: disassociate-sc-actions
       script:
         - sceptre delete $TRAVIS_BRANCH/sc-product-assoc-ec2 --yes
+    - stage: deploy
+      script:
         - sceptre launch $TRAVIS_BRANCH --yes

--- a/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -11,6 +11,7 @@ parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
+  ReplaceProvisioningArtifacts: "true"
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud-notebook.yaml"

--- a/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -11,6 +11,7 @@ parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
+  ReplaceProvisioningArtifacts: "true"
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud-workflows.yaml"

--- a/config/develop/sc-product-ec2-linux-jumpcloud.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud.yaml
@@ -11,6 +11,7 @@ parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
+  ReplaceProvisioningArtifacts: "true"
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud.yaml"

--- a/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -11,6 +11,7 @@ parameters:
   PortfolioId: !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
   RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
   StackDatetime: !date
+  ReplaceProvisioningArtifacts: "true"
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-windows-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-windows-jumpcloud.yaml"


### PR DESCRIPTION
This is a workaround for the  problem that arises from product versions
being replaced. To date we have found no other way to force updates than
to replace product versions. However, we are focused on doing so because
we’re developing. In production, we should release a version and freeze it,
and there is no problem with updates when adding a new version (appending
a new item to the version list).

This PR depends on PR https://github.com/Sage-Bionetworks/service-catalog-library/pull/192