### PR TITLE
[SC-65] Fix template reference

### DIFF
--- a/config/develop/sc-portfolio-ec2-external.yaml
+++ b/config/develop/sc-portfolio-ec2-external.yaml
@@ -1,4 +1,4 @@
-template_path: "remote/sc-portfolio-ec2.yaml"
+template_path: "remote/sc-portfolio-ec2-external.yaml"
 stack_name: "sc-portfolio-ec2-external"
 dependencies:
   - "develop/sc-ec2vpc-launchrole.yaml"

--- a/config/prod/sc-portfolio-ec2-external.yaml
+++ b/config/prod/sc-portfolio-ec2-external.yaml
@@ -1,4 +1,4 @@
-template_path: "remote/sc-portfolio-ec2.yaml"
+template_path: "remote/sc-portfolio-ec2-external.yaml"
 stack_name: "sc-portfolio-ec2-external"
 dependencies:
   - "prod/sc-ec2vpc-launchrole.yaml"


### PR DESCRIPTION
The portfolio for external users referenced the wrong CFN template file.
Fix to use the correct one.