### PR TITLE
Add permission to invoke lambdas to SCEC2LaunchRole's SCLaunchPolicy

### DIFF
--- a/templates/sc-ec2vpc-launchrole.yaml
+++ b/templates/sc-ec2vpc-launchrole.yaml
@@ -57,6 +57,7 @@ Resources:
                   - "cloudformation:UpdateStack"
                   - "cloudformation:CreateChangeSet"
                   - "s3:GetObject"
+                  - "lambda:InvokeFunction"
                 Resource: '*'
 Outputs:
   LaunchRoleArn:


### PR DESCRIPTION
grant the ability to invoke a lambda to the ec2 launch role
