### PR TITLE
[SC-192] Refactor references to product templates

### DIFF
--- a/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -8,6 +8,6 @@ dependencies:
   - "develop/sc-portfolio-ec2.yaml"
   - "develop/sc-ec2-actions.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date
   ReplaceProvisioningArtifacts: "true"

--- a/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -8,6 +8,6 @@ dependencies:
   - "develop/sc-portfolio-ec2.yaml"
   - "develop/sc-ec2-actions.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date
   ReplaceProvisioningArtifacts: "true"

--- a/config/develop/sc-product-ec2-linux-jumpcloud.yaml
+++ b/config/develop/sc-product-ec2-linux-jumpcloud.yaml
@@ -9,6 +9,6 @@ dependencies:
   - "develop/sc-portfolio-ec2-external.yaml"
   - "develop/sc-ec2-actions.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date
   ReplaceProvisioningArtifacts: "true"

--- a/config/develop/sc-product-ec2-windows-jumpcloud.yaml
+++ b/config/develop/sc-product-ec2-windows-jumpcloud.yaml
@@ -8,6 +8,6 @@ dependencies:
   - "develop/sc-portfolio-ec2.yaml"
   - "develop/sc-ec2-actions.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date
   ReplaceProvisioningArtifacts: "true"

--- a/config/develop/sc-product-s3-private-enc.yaml
+++ b/config/develop/sc-product-s3-private-enc.yaml
@@ -7,5 +7,5 @@ stack_tags:
 dependencies:
   - "develop/sc-portfolio-s3-basic.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date

--- a/config/develop/sc-product-s3-synapse.yaml
+++ b/config/develop/sc-product-s3-synapse.yaml
@@ -7,5 +7,5 @@ stack_tags:
 dependencies:
   - "develop/sc-portfolio-s3-basic.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date

--- a/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -7,5 +7,5 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-ec2.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date

--- a/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -7,5 +7,5 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-ec2.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date

--- a/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -8,5 +8,5 @@ dependencies:
   - "prod/sc-portfolio-ec2.yaml"
   - "prod/sc-portfolio-ec2-external.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date

--- a/config/prod/sc-product-ec2-windows-jumpcloud.yaml
+++ b/config/prod/sc-product-ec2-windows-jumpcloud.yaml
@@ -7,5 +7,5 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-ec2.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date

--- a/config/prod/sc-product-s3-private-enc.yaml
+++ b/config/prod/sc-product-s3-private-enc.yaml
@@ -7,5 +7,5 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-s3-basic.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date

--- a/config/prod/sc-product-s3-synapse.yaml
+++ b/config/prod/sc-product-s3-synapse.yaml
@@ -7,5 +7,5 @@ stack_tags:
 dependencies:
   - "prod/sc-portfolio-s3-basic.yaml"
 parameters:
-  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}/v1.0.0/"
+  RepoRootURL: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/{{stack_group_config.service_catalog_library}}"
   StackDatetime: !date

--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -33,15 +33,15 @@ Resources:
       ProvisioningArtifactParameters:
         - Description: 'Baseline version.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml'
           Name: 'v1.0.0'
         - Description: 'Includes fix for a linux relocation error.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.1.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.1.yaml'
           Name: 'v1.0.1'
         - Description: !Sub 'Fix to support multiple portfolios. Last updated at ${StackDatetime}.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.2.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.2.yaml'
           Name: 'v1.0.2'
       'Fn::Transform':
         Name: 'AWS::Include'

--- a/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -33,15 +33,15 @@ Resources:
       ProvisioningArtifactParameters:
         - Description: 'Baseline version.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml'
           Name: 'v1.0.0'
         - Description: 'Includes fix for a linux relocation error.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.1.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.1.yaml'
           Name: 'v1.0.1'
         - Description: !Sub 'Fix to support multiple portfolios. Last updated at ${StackDatetime}.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.2.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.2.yaml'
           Name: 'v1.0.2'
       'Fn::Transform':
         Name: 'AWS::Include'

--- a/templates/sc-product-ec2-linux-jumpcloud.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud.yaml
@@ -33,15 +33,15 @@ Resources:
       ProvisioningArtifactParameters:
         - Description: 'Baseline version.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml'
           Name: 'v1.0.0'
         - Description: 'Includes fix for a linux relocation error.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-v1.0.1.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-v1.0.1.yaml'
           Name: 'v1.0.1'
         - Description: !Sub 'Fix to support multiple portfolios. Last updated at ${StackDatetime}.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-v1.0.2.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-v1.0.2.yaml'
           Name: 'v1.0.2'
       'Fn::Transform':
         Name: 'AWS::Include'

--- a/templates/sc-product-ec2-windows-jumpcloud.yaml
+++ b/templates/sc-product-ec2-windows-jumpcloud.yaml
@@ -33,7 +33,7 @@ Resources:
       ProvisioningArtifactParameters:
         - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml'
           Name: 'v1.0.0'
       'Fn::Transform':
         Name: 'AWS::Include'

--- a/templates/sc-product-s3-private-enc.yaml
+++ b/templates/sc-product-s3-private-enc.yaml
@@ -29,11 +29,11 @@ Resources:
       ProvisioningArtifactParameters:
         - Description: 'Baseline version.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-encrypted-ra-v1.0.0.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/s3/sc-s3-encrypted-ra-v1.0.0.yaml'
           Name: 'v1.0.0'
         - Description: !Sub 'Fix resource contention bug with S3 custom resources. Last updated at ${StackDatetime}.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-encrypted-ra-v1.0.0.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/s3/sc-s3-encrypted-ra-v1.0.1.yaml'
           Name: 'v1.0.1'
       'Fn::Transform':
         Name: 'AWS::Include'

--- a/templates/sc-product-s3-synapse.yaml
+++ b/templates/sc-product-s3-synapse.yaml
@@ -29,15 +29,15 @@ Resources:
       ProvisioningArtifactParameters:
         - Description: 'Baseline version.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-synapse-ra-v1.0.0.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/s3/sc-s3-synapse-ra-v1.0.0.yaml'
           Name: 'v1.0.0'
         - Description: 'Remove SynapseProdARN parameter.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-synapse-ra-v1.0.1.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/s3/sc-s3-synapse-ra-v1.0.1.yaml'
           Name: 'v1.0.1'
         - Description: !Sub 'Fix resource contention bug with S3 custom resources. Last updated at ${StackDatetime}.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-synapse-ra-v1.0.2.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/s3/sc-s3-synapse-ra-v1.0.2.yaml'
           Name: 'v1.0.2'
       'Fn::Transform':
         Name: 'AWS::Include'


### PR DESCRIPTION
New tags were created in https://github.com/Sage-Bionetworks/service-catalog-library/tags
so now we can properly reference from a tagged directory of files in S3

The versions v1.0.0, v1.0.1, and v1.0.2 are all identical.  The idea
behind creating idential versions is so we can match the version of the
S3 bucket folder with the version on the file.  If we didn't create
multiple versions we would have to reference with `v1.0.0` for the
folder and `sc-ec2-linux-jumpcloud-v1.0.2.yaml` for the file which
would be pretty confusing. i.e.:
```
- Description: !Sub 'Fix to support multiple portfolios. Last updated at ${StackDatetime}.'
  Info:
    LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-linux-jumpcloud-v1.0.2.yaml'
  Name: 'v1.0.2'
```

Also I didn't wanted to keep the existing references the same as much as
possible otherwise AWS may create new product versions.

On the next version we will no longer have version info in the file.  it
will be something like this..
```
- Description: !Sub 'Fix to support multiple portfolios. Last updated at ${StackDatetime}.'
  Info:
    LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.1/ec2/sc-ec2-linux-jumpcloud.yaml'
  Name: 'v1.1.1'
```