### PR TITLE
SC-135 ALB->Notebooks resources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.1.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/adrienverge/yamllint
-    rev: v1.17.0
+    rev: v1.23.0
     hooks:
     -   id: yamllint
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.23.3
+    rev: v0.33.2
     hooks:
     -   id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.6
+    rev: v1.1.7
     hooks:
     -   id: remove-tabs

--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: 2010-09-09
+template_path: alb-notebook-access.yaml
+stack_name: alb-notebook-access
+parameters:
+  DomainName: "sageit.org"
+  SubDomainName: "connect"
+# SSLCertificateArn: "us-east-1-synapse-login-scipooldev-sageit-cert-SSLCertificateSageIT"
+  VpcSubnet: PublicSubnet
+  VpcName: cesspoolvpc

--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -2,9 +2,9 @@ AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 parameters:
-  DomainName: "scipooldev.org"
+  DomainName: "connect.scipooldev.org" #must be a subdomain.domain.tld that does not exist
   Vpc: !stack_output_external cesspoolvpc::VPCId
   VpcPublicSubnetA: !stack_output_external cesspoolvpc::PublicSubnet
   VpcPublicSubnetB: !stack_output_external cesspoolvpc::PublicSubnet1
   VpcPublicSubnetC: !stack_output_external cesspoolvpc::PublicSubnet2
-  SSLCertificateArn: 'arn:aws:acm:us-east-1:465877038949:certificate/10b9fef3-6e54-49e7-abf9-8484b6808c2a'
+  SSLCertificateArn: !stack_outpu_external synapse-login-scipooldev-base::SSLCertificate

--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPublicSubnetA: !stack_output_external cesspoolvpc::PublicSubnet
   VpcPublicSubnetB: !stack_output_external cesspoolvpc::PublicSubnet1
   VpcPublicSubnetC: !stack_output_external cesspoolvpc::PublicSubnet2
-  SSLCertificateArn: !stack_outpu_external synapse-login-scipooldev-base::SSLCertificate
+  SSLCertificateArn: !stack_output_external synapse-login-scipooldev-base::SSLCertificate

--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -5,5 +5,5 @@ parameters:
   DomainName: "sageit.org"
   SubDomainName: "connect"
 # SSLCertificateArn: "us-east-1-synapse-login-scipooldev-sageit-cert-SSLCertificateSageIT"
-  VpcSubnet: PublicSubnet
+# VpcSubnet: PublicSubnet
   VpcName: cesspoolvpc

--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -2,8 +2,9 @@ AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 parameters:
-  DomainName: "sageit.org"
-  SubDomainName: "connect"
-# SSLCertificateArn: "us-east-1-synapse-login-scipooldev-sageit-cert-SSLCertificateSageIT"
-# VpcSubnet: PublicSubnet
-  VpcName: cesspoolvpc
+  DomainName: "scipooldev.org"
+  Vpc: !stack_output_external cesspoolvpc::VPCId
+  VpcPublicSubnetA: !stack_output_external cesspoolvpc::PublicSubnet
+  VpcPublicSubnetB: !stack_output_external cesspoolvpc::PublicSubnet1
+  VpcPublicSubnetC: !stack_output_external cesspoolvpc::PublicSubnet2
+  SSLCertificateArn: 'arn:aws:acm:us-east-1:465877038949:certificate/10b9fef3-6e54-49e7-abf9-8484b6808c2a'

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -5,195 +5,29 @@ Parameters:
   DomainName:
     Description: 'Domain or string to register new CNAME for ALB'
     Type: String
-  SubDomainName:
-    Description: 'Sub-domain name for DNS record and cert'
-    Type: String
-#   Default: "*" #can default to wildcard cert, but require subdomain for now
-# SSLCertificateArn:
-#   Description: 'ARN of Certificate to attach to ALB'
-#   Type: String
-# VpcSubnet:
-#   Description: 'Existing public VPC subnet name to run the instance in'
-#   Type: String
-#   Default: PublicSubnet
-#   ConstraintDescription: >-
-#     Allowed values (PublicSubnet, PublicSubnet1, PublicSubnet2)
-#   AllowedValues:
-#     - PublicSubnet
-#     - PublicSubnet1
-#     - PublicSubnet2
-  VpcName:
-    Description: 'Name of an existing VPC to run the instance in'
+  VPC:
+    Description: 'VPC id for homing the ALB'
+    Type: 'AWS::EC2::VPC::Id'
+  VpcPublicSubnetA:
+    Description: 'First public subnet for redundancy'
+    Type: 'AWS::EC2::Subnet::Id'
+  VpcPublicSubnetB:
+    Description: 'Second public subnet for redundancy'
+    Type: 'AWS::EC2::Subnet::Id'
+  VpcPublicSubnetC:
+    Description: 'Third public subnet for redundancy'
+    Type: 'AWS::EC2::Subnet::Id'
+  SSLCertificateArn:
+    Description: 'ARN for a certificate that exists in the account and is valid for the domain'
     Type: String
 
 Resources:
-
-  KmsDecryptManagedPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: ReadAccess
-            Action:
-              - 'kms:ListKeys'
-              - 'kms:ListAliases'
-              - 'kms:DescribeKey'
-              - 'kms:ListKeyPolicies'
-              - 'kms:GetKeyPolicy'
-              - 'kms:GetKeyRotationStatus'
-              - 'iam:ListUsers'
-              - 'iam:ListRoles'
-            Effect: Allow
-            Resource: !ImportValue
-              'Fn::Sub': '${AWS::Region}-${AWS::StackName}-KmsKeyArn'
-          - Sid: DecryptAccess
-            Action:
-              - 'kms:Encrypt'
-              - 'kms:Decrypt'
-            Effect: Allow
-            Resource: !ImportValue
-              'Fn::Sub': '${AWS::Region}-${AWS::StackName}-KmsKeyArn'
-
-  SsmManagedPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: GetParamAccess
-            Action:
-              - 'ssm:*'
-            Effect: Allow
-            Resource: !Join
-              - ''
-              - - 'arn:aws:ssm:'
-                - !Ref AWS::Region
-                - ':'
-                - !Ref AWS::AccountId
-                - ':'
-                - 'parameter/'
-                - !Ref AWS::StackName
-                - '/*'
-
-  KmsKey:
-    Type: AWS::KMS::Key
-    Properties:
-      Description: !Join
-        - '-'
-        - - !Ref AWS::StackName
-          - "KmsKey"
-      KeyPolicy:
-        Version: "2012-10-17"
-        Statement:
-          -
-            Sid: "Allow administration of the key"
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - !Join
-                  - ''
-                  - - 'arn:aws:iam::'
-                    - !Ref AWS::AccountId
-                    - ':root'
-                - !ImportValue
-                    'Fn::Sub': '${AWS::Region}-bootstrap-CfServiceRoleArn'
-            Action:
-              - "kms:Create*"
-              - "kms:Describe*"
-              - "kms:Enable*"
-              - "kms:List*"
-              - "kms:Put*"
-              - "kms:Update*"
-              - "kms:Revoke*"
-              - "kms:Disable*"
-              - "kms:Get*"
-              - "kms:Delete*"
-              - "kms:ScheduleKeyDeletion"
-              - "kms:CancelKeyDeletion"
-            Resource: "*"
-          -
-            Sid: "Allow use of the key"
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - !Join
-                  - ''
-                  - - 'arn:aws:iam::'
-                    - !Ref AWS::AccountId
-                    - ':root'
-                - !ImportValue
-                    'Fn::Sub': '${AWS::Region}-bootstrap-CfServiceRoleArn'
-            Action:
-              - "kms:Encrypt"
-              - "kms:Decrypt"
-              - "kms:ReEncrypt*"
-              - "kms:GenerateDataKey*"
-              - "kms:DescribeKey"
-            Resource: "*"
-
-  KmsKeyAlias:
-    Type: AWS::KMS::Alias
-    Properties:
-      AliasName: !Join
-        - ''
-        - - 'alias/'
-          - !Ref AWS::StackName
-          - '/KmsKey'
-      TargetKeyId: !Ref KmsKey
-
-  DomainCertificate:
-    Type: AWS::CertificateManager::Certificate
-    Properties:
-      DomainName: !Join
-        - '.'
-        - - !Ref SubDomainName
-          - !Ref DomainName
-      DomainValidationOptions:
-        - DomainName: !Join
-            - '.'
-            - - !Ref SubDomainName
-              - !Ref DomainName
-          ValidationDomain: !Ref DomainName
-      ValidationMethod: "DNS"
-
-  ALBListenerRuleFunctionRole: # execute lambda function with this role
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      ManagedPolicyArns:
-        - !Ref SsmManagedPolicy
-        - !Ref KmsDecryptManagedPolicy
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-#       - arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
-        - !Ref ALBListenerRuleWritePolicy
-
-  ALBListenerRuleWritePolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: ElbFullAccess
-            Effect: 'Allow'
-            Action:
-              - 'elasticloadbalancing:*'
-            Resource: !Ref ApplicationLoadBalancer
 
   EC2SecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: 'Add ingress to 443 from ALB'
-      VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
+      VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 443
@@ -204,8 +38,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: 'Allow ingress to 443 from everywhere'
-      VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
+      VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 443
@@ -218,7 +51,7 @@ Resources:
       LoadBalancerArn:
         Ref: ApplicationLoadBalancer
       Certificates:
-        - CertificateArn: !Ref DomainCertificate
+        - CertificateArn: !Ref SSLCertificateArn
       DefaultActions:
         - Type: redirect
           Order: 50000
@@ -233,13 +66,13 @@ Resources:
     Properties:
       Scheme: internet-facing
       Subnets:
-      - PublicSubnet
-      - PublicSubnet1
-      - PublicSubnet2
+      - !Ref VpcPublicSubnetA
+      - !Ref VpcPublicSubnetB
+      - !Ref VpcPublicSubnetC
       SecurityGroups:
-      - Ref: ALBSecurityGroup
+      - !Ref ALBSecurityGroup
 
-  ConnectDNSRecord: #TODO should we output a connection string based on this?
+  ConnectDNSRecord:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneName: !Sub '${DomainName}.'
@@ -250,16 +83,6 @@ Resources:
       - !GetAtt ApplicationLoadBalancer.DNSName
 
 Outputs:
-  ALBListenerRuleFunctionRole:
-    Description: 'Role reference for the Ruler lambda'
-    Value: !Ref ALBListenerRuleFunctionRole
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBListenerRuleFunctionRole'
-  ALBListenerRuleFunctionRoleArn:
-    Description: 'Role ARN for the Ruler lambda'
-    Value: !GetAtt ALBListenerRuleFunctionRole.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBListenerRuleFunctionRoleArn'
   ALBSecurityGroup:
     Description: 'Security group allowing public ingress to the ALB'
     Value: !Ref ALBSecurityGroup
@@ -282,42 +105,15 @@ Outputs:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerArn'
   ApplicationLoadBalancerDirectHTTPSConnectionURI:
     Description: 'Connection string for ALB'
-    Value:
-      !Join
-      - ''
-      - - https://
-        - Fn::GetAtt:
-          - ApplicationLoadBalancer
-          - DNSName
+    Value: !Join ['', ['https://', !GetAtt ApplicationLoadBalancer.DNSName]]
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerDirectHTTPSConnectionURI'
-  ConnectionURI:
-    Value: !Join
-           - ''
-           - - https://
-             - !Ref SubDomainName
-             - '.'
-             - !Ref DomainName
+  ConnectionURI:  #Change this value based on which routing method (dns name vs. path) works best
+    Value: !Join ['', ['https://', !Ref DomainName]]
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ConnectionURI'
-  DomainCertificateArn:
-    Value: !Ref DomainCertificate
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-DomainCertificateArn'
   EC2SecurityGroup:
     Description: 'Security group allowing ingress to an instance from the ALB'
     Value: !Ref EC2SecurityGroup
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-EC2SecurityGroup'
-  KmsKey:
-    Value: !Ref KmsKey
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsKey'
-  KmsKeyAlias:
-    Value: !Ref KmsKeyAlias
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsKeyAlias'
-  KmsKeyArn:
-    Value: !GetAtt KmsKey.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsKeyArn'

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -6,7 +6,7 @@ Parameters:
     Description: 'Domain or string to register new CNAME for ALB'
     Type: String
   VPC:
-    Description: 'VPC id for homing the ALB'
+    Description: 'VPC id for holding the ALB'
     Type: 'AWS::EC2::VPC::Id'
   VpcPublicSubnetA:
     Description: 'First public subnet for redundancy'
@@ -98,11 +98,11 @@ Outputs:
     Value: !Ref ApplicationLoadBalancer
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancer'
-  ApplicationLoadBalancerARN:
-    Description: 'Application Load Balancer Arn'
-    Value: !Ref ApplicationLoadBalancer
+  ALBListenerARN:
+    Description: 'ARN of the ALB Listener'
+    Value: !Ref ALBListener
     Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerArn'
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBListenerARN'
   ApplicationLoadBalancerDirectHTTPSConnectionURI:
     Description: 'Connection string for ALB'
     Value: !Join ['', ['https://', !GetAtt ApplicationLoadBalancer.DNSName]]

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -78,7 +78,7 @@ Resources:
       HostedZoneName: !Sub '${DomainName}.'
       Name: !Ref DomainName
       Type: CNAME
-      TTL: '900'
+      TTL: 900
       ResourceRecords:
       - !GetAtt ApplicationLoadBalancer.DNSName
 

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -1,0 +1,320 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Create ALB that can be modified by Service Catalog provisioning requests
+
+Parameters:
+  DomainName:
+    Description: 'Domain or string to register new CNAME for ALB'
+    Type: String
+  SubDomainName:
+    Description: 'Sub-domain name for DNS record and cert'
+    Type: String
+#   Default: "*" #can default to wildcard cert, but require subdomain for now
+# SSLCertificateArn:
+#   Description: 'ARN of Certificate to attach to ALB'
+#   Type: String
+  VpcSubnet:
+    Description: 'Existing public VPC subnet name to run the instance in'
+    Type: String
+    Default: PublicSubnet
+    ConstraintDescription: >-
+      Allowed values (PublicSubnet, PublicSubnet1, PublicSubnet2)
+    AllowedValues:
+      - PublicSubnet
+      - PublicSubnet1
+      - PublicSubnet2
+  VpcName:
+    Description: 'Name of an existing VPC to run the instance in'
+    Type: String
+
+Resources:
+
+  KmsDecryptManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ReadAccess
+            Action:
+              - 'kms:ListKeys'
+              - 'kms:ListAliases'
+              - 'kms:DescribeKey'
+              - 'kms:ListKeyPolicies'
+              - 'kms:GetKeyPolicy'
+              - 'kms:GetKeyRotationStatus'
+              - 'iam:ListUsers'
+              - 'iam:ListRoles'
+            Effect: Allow
+            Resource: !ImportValue 
+              'Fn::Sub': '${AWS::Region}-${AWS::StackName}-KmsKeyArn'
+          - Sid: DecryptAccess
+            Action:
+              - 'kms:Encrypt'
+              - 'kms:Decrypt'
+            Effect: Allow
+            Resource: !ImportValue 
+              'Fn::Sub': '${AWS::Region}-${AWS::StackName}-KmsKeyArn'
+
+  SsmManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: GetParamAccess
+            Action:
+              - 'ssm:*'
+            Effect: Allow
+            Resource: !Join
+              - ''
+              - - 'arn:aws:ssm:'
+                - !Ref AWS::Region
+                - ':'
+                - !Ref AWS::AccountId
+                - ':'
+                - 'parameter/'
+                - !Ref AWS::StackName
+                - '/*'
+
+  KmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: !Join
+        - '-'
+        - - !Ref AWS::StackName
+          - "KmsKey"
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: "Allow administration of the key"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !Join
+                  - ''
+                  - - 'arn:aws:iam::'
+                    - !Ref AWS::AccountId
+                    - ':root'
+                - !ImportValue 
+                    'Fn::Sub': '${AWS::Region}-bootstrap-CfServiceRoleArn'
+            Action:
+              - "kms:Create*"
+              - "kms:Describe*"
+              - "kms:Enable*"
+              - "kms:List*"
+              - "kms:Put*"
+              - "kms:Update*"
+              - "kms:Revoke*"
+              - "kms:Disable*"
+              - "kms:Get*"
+              - "kms:Delete*"
+              - "kms:ScheduleKeyDeletion"
+              - "kms:CancelKeyDeletion"
+            Resource: "*"
+          -
+            Sid: "Allow use of the key"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !Join
+                  - ''
+                  - - 'arn:aws:iam::'
+                    - !Ref AWS::AccountId
+                    - ':root'
+                - !ImportValue 
+                    'Fn::Sub': '${AWS::Region}-bootstrap-CfServiceRoleArn'
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+            Resource: "*"
+
+  KmsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Join
+        - ''
+        - - 'alias/'
+          - !Ref AWS::StackName
+          - '/KmsKey'
+      TargetKeyId: !Ref KmsKey
+
+  DomainCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Join
+        - '.'
+        - - !Ref SubDomainName
+          - !Ref DomainName
+      DomainValidationOptions:
+        - DomainName: !Join
+            - '.'
+            - - !Ref SubDomainName
+              - !Ref DomainName
+          ValidationDomain: !Ref DomainName
+      ValidationMethod: "DNS"
+
+  ALBListenerRuleFunctionRole: # execute lambda function with this role
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Ref SsmManagedPolicy
+        - !Ref KmsDecryptManagedPolicy
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+#       - arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
+        - !Ref ALBListenerRuleWritePolicy
+
+  ALBListenerRuleWritePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: ElbFullAccess
+            Effect: 'Allow'
+            Action:
+              - 'elasticloadbalancing:*'
+            Resource: !Ref ApplicationLoadBalancer
+
+  EC2SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: 'Add ingress to 443 from ALB'
+      VpcId:  !ImportValue
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443 
+          ToPort: 443 
+          SourceSecurityGroupId: !Ref ALBSecurityGroup
+
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: 'Allow ingress to 443 from everywhere'
+      VpcId:  !ImportValue
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443 
+          ToPort: 443 
+          CidrIp: 0.0.0.0/0
+
+  ALBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn:
+        Ref: ApplicationLoadBalancer
+        Certificates: !Ref DomainCertificate
+        DefaultActions:
+          - Type: redirect
+            Order: 50000
+            RedirectToDefaultDomain:
+              Host: !Ref DomainName
+              StatusCode: HTTP_301
+        Port: 443 
+        Protocol: HTTPS 
+
+  ApplicationLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      Subnets:
+      - Ref: VpcSubnet
+      SecurityGroups:
+      - Ref: ALBSecurityGroup
+
+  ConnectDNSRecord: #TODO should we output a connection string based on this?
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName: !Sub '${DomainName}.'
+      Name: !Ref DomainName
+      Type: CNAME
+      TTL: '900'
+      ResourceRecords:
+      - !GetAtt ApplicationLoadBalancer.DNSName
+
+Outputs:
+  ALBListenerRuleFunctionRole:
+    Description: 'Role reference for the Ruler lambda'
+    Value: !Ref ALBListenerRuleFunctionRole
+    Export: 
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBListenerRuleFunctionRole'
+  ALBListenerRuleFunctionRole:
+    Description: 'Role ARN for the Ruler lambda'
+    Value: !GetAtt ALBListenerRuleFunctionRole.Arn
+    Export: 
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBListenerRuleFunctionRole'
+  ALBSecurityGroup:
+    Description: 'Security group allowing public ingress to the ALB'
+    Value: !Ref ALBSecurityGroup
+    Export: 
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBSecurityGroup'
+  ApplicationLoadBalancerDNSName:
+    Description: 'Public DNS name of the ALB'
+    Value: !GetAtt ApplicationLoadBalancer.DNSName
+    Export: 
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerDNSName'
+  ApplicationLoadBalancer:
+    Description: 'Application Load Balancer'
+    Value: !Ref ApplicationLoadBalancer
+    Export: 
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancer'
+  ApplicationLoadBalancerARN:
+    Description: 'Application Load Balancer Arn'
+    Value: !Ref ApplicationLoadBalancer
+    Export: 
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerArn'
+  ApplicationLoadBalancerDirectHTTPSConnectionURI: 
+    Description: 'Connection string for ALB'
+    Value:
+      !Join
+      - ''
+      - - https://
+        - Fn::GetAtt:
+          - ApplicationLoadBalancer
+          - DNSName
+    Export: 
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerDirectHTTPSConnectionURI'
+  ConnectionURI:
+    Value: !Join 
+           - ''
+           - - https://
+             - !Ref SubDomainName
+             - '.'
+             - !Ref DomainName
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ConnectionURI'
+  DomainCertificateArn:
+    Value: !Ref DomainCertificate
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DomainCertificateArn'
+  EC2SecurityGroup:
+    Description: 'Security group allowing ingress to an instance from the ALB'
+    Value: !Ref EC2SecurityGroup
+    Export: 
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EC2SecurityGroup'
+  KmsKey:
+    Value: !Ref KmsKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsKey'
+  KmsKeyAlias:
+    Value: !Ref KmsKeyAlias
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsKeyAlias'
+  KmsKeyArn:
+    Value: !GetAtt KmsKey.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsKeyArn'

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -12,16 +12,16 @@ Parameters:
 # SSLCertificateArn:
 #   Description: 'ARN of Certificate to attach to ALB'
 #   Type: String
-  VpcSubnet:
-    Description: 'Existing public VPC subnet name to run the instance in'
-    Type: String
-    Default: PublicSubnet
-    ConstraintDescription: >-
-      Allowed values (PublicSubnet, PublicSubnet1, PublicSubnet2)
-    AllowedValues:
-      - PublicSubnet
-      - PublicSubnet1
-      - PublicSubnet2
+# VpcSubnet:
+#   Description: 'Existing public VPC subnet name to run the instance in'
+#   Type: String
+#   Default: PublicSubnet
+#   ConstraintDescription: >-
+#     Allowed values (PublicSubnet, PublicSubnet1, PublicSubnet2)
+#   AllowedValues:
+#     - PublicSubnet
+#     - PublicSubnet1
+#     - PublicSubnet2
   VpcName:
     Description: 'Name of an existing VPC to run the instance in'
     Type: String
@@ -45,14 +45,14 @@ Resources:
               - 'iam:ListUsers'
               - 'iam:ListRoles'
             Effect: Allow
-            Resource: !ImportValue 
+            Resource: !ImportValue
               'Fn::Sub': '${AWS::Region}-${AWS::StackName}-KmsKeyArn'
           - Sid: DecryptAccess
             Action:
               - 'kms:Encrypt'
               - 'kms:Decrypt'
             Effect: Allow
-            Resource: !ImportValue 
+            Resource: !ImportValue
               'Fn::Sub': '${AWS::Region}-${AWS::StackName}-KmsKeyArn'
 
   SsmManagedPolicy:
@@ -96,7 +96,7 @@ Resources:
                   - - 'arn:aws:iam::'
                     - !Ref AWS::AccountId
                     - ':root'
-                - !ImportValue 
+                - !ImportValue
                     'Fn::Sub': '${AWS::Region}-bootstrap-CfServiceRoleArn'
             Action:
               - "kms:Create*"
@@ -122,7 +122,7 @@ Resources:
                   - - 'arn:aws:iam::'
                     - !Ref AWS::AccountId
                     - ':root'
-                - !ImportValue 
+                - !ImportValue
                     'Fn::Sub': '${AWS::Region}-bootstrap-CfServiceRoleArn'
             Action:
               - "kms:Encrypt"
@@ -192,24 +192,24 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: 'Add ingress to 443 from ALB'
-      VpcId:  !ImportValue
+      VpcId: !ImportValue
         'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: 443 
-          ToPort: 443 
+          FromPort: 443
+          ToPort: 443
           SourceSecurityGroupId: !Ref ALBSecurityGroup
 
   ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: 'Allow ingress to 443 from everywhere'
-      VpcId:  !ImportValue
+      VpcId: !ImportValue
         'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: 443 
-          ToPort: 443 
+          FromPort: 443
+          ToPort: 443
           CidrIp: 0.0.0.0/0
 
   ALBListener:
@@ -217,22 +217,25 @@ Resources:
     Properties:
       LoadBalancerArn:
         Ref: ApplicationLoadBalancer
-        Certificates: !Ref DomainCertificate
-        DefaultActions:
-          - Type: redirect
-            Order: 50000
-            RedirectToDefaultDomain:
-              Host: !Ref DomainName
-              StatusCode: HTTP_301
-        Port: 443 
-        Protocol: HTTPS 
+      Certificates:
+        - CertificateArn: !Ref DomainCertificate
+      DefaultActions:
+        - Type: redirect
+          Order: 50000
+          RedirectConfig:
+            Host: !Ref DomainName
+            StatusCode: HTTP_301
+      Port: 443
+      Protocol: HTTPS
 
   ApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Scheme: internet-facing
       Subnets:
-      - Ref: VpcSubnet
+      - PublicSubnet
+      - PublicSubnet1
+      - PublicSubnet2
       SecurityGroups:
       - Ref: ALBSecurityGroup
 
@@ -250,34 +253,34 @@ Outputs:
   ALBListenerRuleFunctionRole:
     Description: 'Role reference for the Ruler lambda'
     Value: !Ref ALBListenerRuleFunctionRole
-    Export: 
+    Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBListenerRuleFunctionRole'
-  ALBListenerRuleFunctionRole:
+  ALBListenerRuleFunctionRoleArn:
     Description: 'Role ARN for the Ruler lambda'
     Value: !GetAtt ALBListenerRuleFunctionRole.Arn
-    Export: 
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBListenerRuleFunctionRole'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBListenerRuleFunctionRoleArn'
   ALBSecurityGroup:
     Description: 'Security group allowing public ingress to the ALB'
     Value: !Ref ALBSecurityGroup
-    Export: 
+    Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBSecurityGroup'
   ApplicationLoadBalancerDNSName:
     Description: 'Public DNS name of the ALB'
     Value: !GetAtt ApplicationLoadBalancer.DNSName
-    Export: 
+    Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerDNSName'
   ApplicationLoadBalancer:
     Description: 'Application Load Balancer'
     Value: !Ref ApplicationLoadBalancer
-    Export: 
+    Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancer'
   ApplicationLoadBalancerARN:
     Description: 'Application Load Balancer Arn'
     Value: !Ref ApplicationLoadBalancer
-    Export: 
+    Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerArn'
-  ApplicationLoadBalancerDirectHTTPSConnectionURI: 
+  ApplicationLoadBalancerDirectHTTPSConnectionURI:
     Description: 'Connection string for ALB'
     Value:
       !Join
@@ -286,10 +289,10 @@ Outputs:
         - Fn::GetAtt:
           - ApplicationLoadBalancer
           - DNSName
-    Export: 
+    Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerDirectHTTPSConnectionURI'
   ConnectionURI:
-    Value: !Join 
+    Value: !Join
            - ''
            - - https://
              - !Ref SubDomainName
@@ -304,7 +307,7 @@ Outputs:
   EC2SecurityGroup:
     Description: 'Security group allowing ingress to an instance from the ALB'
     Value: !Ref EC2SecurityGroup
-    Export: 
+    Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-EC2SecurityGroup'
   KmsKey:
     Value: !Ref KmsKey


### PR DESCRIPTION
This PR does a few things:
1. Creates an ALB and a policy that allows a lambda to add rules to it. This policy is exported in a role that can be imported by the lambda.
2. Creates a KMS key following our convention for administering the key (we may want to expand administration rights on this KMS key). There is an associated KMS read/decrypt policy and SSM parameter read policy that are included in the role for the lambda. The lambda function will need to recreate the OIDC auth step for every rule it adds to the ALB and so will need access to the ODIC client secret which will be an secret string in SSM.
3. Creates an SSL cert for an input sub.domain parameter. We already have wildcard certs at the root of a few domains, but I'm leaving this piece in place so we can define complete ConnectionURI strings beyond what we already have, with certs tied to the stack. 
4. Defines a security group to add to notebook instances to allow ingress on HTTPS/443: https://github.com/Sage-Bionetworks/service-catalog-library/pull/213
This has passed validation but hasn't been tested, so I'm marking it as draft for feedback to get reviewer ideas before testing.