### PR TITLE
Fix sceptre deploy and subdomain CNAME

### DIFF
--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -3,6 +3,7 @@ template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 parameters:
   DomainName: "scipooldev.org"
+  SubDomainName: "connect"
   VPC: !stack_output_external cesspoolvpc::VPCId
   VpcPublicSubnetA: !stack_output_external cesspoolvpc::PublicSubnet
   VpcPublicSubnetB: !stack_output_external cesspoolvpc::PublicSubnet1

--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 parameters:
-  DomainName: "scipooldev.org" 
+  DomainName: "scipooldev.org"
   VPC: !stack_output_external cesspoolvpc::VPCId
   VpcPublicSubnetA: !stack_output_external cesspoolvpc::PublicSubnet
   VpcPublicSubnetB: !stack_output_external cesspoolvpc::PublicSubnet1

--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -2,8 +2,8 @@ AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 parameters:
-  DomainName: "connect.scipooldev.org" #must be a subdomain.domain.tld that does not exist
-  Vpc: !stack_output_external cesspoolvpc::VPCId
+  DomainName: "scipooldev.org" 
+  VPC: !stack_output_external cesspoolvpc::VPCId
   VpcPublicSubnetA: !stack_output_external cesspoolvpc::PublicSubnet
   VpcPublicSubnetB: !stack_output_external cesspoolvpc::PublicSubnet1
   VpcPublicSubnetC: !stack_output_external cesspoolvpc::PublicSubnet2

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -76,7 +76,7 @@ Resources:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneName: !Sub '${DomainName}.'
-      Name: !Ref DomainName
+      Name: !Join ['', ['connect.', !Ref DomainName]] #hard-coded subdomain points to ALB
       Type: CNAME
       TTL: 900
       ResourceRecords:

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -5,6 +5,9 @@ Parameters:
   DomainName:
     Description: 'Domain or string to register new CNAME for ALB'
     Type: String
+  SubDomainName:
+    Description: 'Domain or string to register new CNAME for ALB'
+    Type: String
   VPC:
     Description: 'VPC id for holding the ALB'
     Type: 'AWS::EC2::VPC::Id'
@@ -76,7 +79,7 @@ Resources:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneName: !Sub '${DomainName}.'
-      Name: !Join ['', ['connect.', !Ref DomainName]] #hard-coded subdomain points to ALB
+      Name: !Join ['', [!Ref SubDomainName, ., !Ref DomainName]]
       Type: CNAME
       TTL: 900
       ResourceRecords:
@@ -109,7 +112,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancerDirectHTTPSConnectionURI'
   ConnectionURI:  #Change this value based on which routing method (dns name vs. path) works best
-    Value: !Join ['', ['https://', !Ref DomainName]]
+    Value: !Join ['', ['https://', !Ref SubDomainName, ., !Ref DomainName]]
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ConnectionURI'
   EC2SecurityGroup:


### PR DESCRIPTION
This PR fixes the sceptre deployment, which had a name mismatch, and fixes the Route 53 CNAME record pointing to the ALB. The subdomain is made variable as a new input to the sceptre config.