### PR TITLE
[IT-876] reference oidc idp provider at new location

### DIFF
--- a/config/develop/synapse-oidc-idp.yaml
+++ b/config/develop/synapse-oidc-idp.yaml
@@ -1,4 +1,4 @@
-template_path: remote/cfn-oidc-identity-provider.yaml
+template_path: remote/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"
@@ -10,4 +10,4 @@ parameters:
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-oidc-identity-provider.yaml --create-dirs -o templates/remote/cfn-oidc-identity-provider.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml --create-dirs -o templates/remote/cfn-cr-oidc-idp.yaml"

--- a/config/prod/synapse-oidc-idp.yaml
+++ b/config/prod/synapse-oidc-idp.yaml
@@ -1,4 +1,4 @@
-template_path: remote/cfn-oidc-identity-provider.yaml
+template_path: remote/cfn-cr-oidc-idp.yaml
 stack_name: synapse-oidc-idp
 stack_tags:
   Department: "Platform"
@@ -10,4 +10,4 @@ parameters:
   ThumbprintList: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-oidc-identity-provider.yaml --create-dirs -o templates/remote/cfn-oidc-identity-provider.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-oidc-idp/master/cfn-cr-oidc-idp.yaml --create-dirs -o templates/remote/cfn-cr-oidc-idp.yaml"


### PR DESCRIPTION
The OIDC IDP provider has moved from Sage-Bionetworks to
Sage-Bionetworks-IT org.  Updating sceptre template to get
the lambda from new location.

depends on https://github.com/Sage-Bionetworks-IT/cfn-cr-oidc-idp/pull/1