### PR TITLE
New version of notebook for alb-rule CR

### DIFF
--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -39,10 +39,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.1.yaml'
           Name: 'v1.0.1'
-        - Description: !Sub 'Fix to support multiple portfolios. Last updated at ${StackDatetime}.'
+        - Description: 'Fix to support multiple portfolios.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.2.yaml'
           Name: 'v1.0.2'
+        - Description: !Sub 'Adds alb-listener-rule custom resource, enabling connection outside VPN. Last updated at ${StackDatetime}'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.1/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+          Name: 'v1.1.1'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:


### PR DESCRIPTION
New version that will use the new alb-rule-making custom resource

Depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/214
Also depends on creating a tag when that ^^ is merged. Assuming next tag will be v1.1.1.
