### PR TITLE
Add ALB logging within account

### DIFF
--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -67,7 +67,6 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-#     BucketName: !Sub ${AWS::StackName}-weblogs
       AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -24,6 +24,15 @@ Parameters:
     Description: 'ARN for a certificate that exists in the account and is valid for the domain'
     Type: String
 
+Mappings:
+  ELBAccountsMap:
+    us-east-1:
+      "ELBAccountRoot": "arn:aws:iam:127311923021:root"
+    us-west-2:
+      "ELBAccountRoot": "arn:aws:iam:797873946194:root"
+    us-west-1:
+      "ELBAccountRoot": "arn:aws:iam:027434742980:root"
+
 Resources:
 
   ALBSecurityGroup:
@@ -53,6 +62,55 @@ Resources:
       Port: 443
       Protocol: HTTPS
 
+  ALBAccessLogsBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub ${AWS::Region}-${AWS::StackName}-access
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+        - ExpirationInDays: 90
+          Status: Enabled
+
+# AWS required policy for writing ALB logs:
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+  ALBAccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ALBAccessLogsBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowALBAccountWrite
+            Effect: Allow
+            Principal:
+              AWS: !FindInMap [ ELBAccountsMap, !Ref "AWS::Region", ELBAccountRoot ]
+            Action: s3:PutObject
+            Resource:
+              - !Sub ${ALBAccessLogsBucket.Arn}/*
+          - Sid: AllowAwsServiceWrite
+            Effect: Allow
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Action: s3:PutObject
+            Resource:
+              - !Sub ${ALBAccessLogsBucket.Arn}/*
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+          - Sid: AllowAwsServiceAclCheck
+            Effect: Allow
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource:
+              - !GetAtt ALBAccessLogsBucket.Arn
+
   ApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -63,6 +121,13 @@ Resources:
       - !Ref VpcPublicSubnetC
       SecurityGroups:
       - !Ref ALBSecurityGroup
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: 'true'
+        - Key: access_logs.s3.bucket
+          Value: !Ref ALBAccessLogsBucket
+        - Key: access_logs.s3.prefix
+          Value: !Join ['', [!Ref SubDomainName, ., !Ref DomainName, "-access"]]
 
   ConnectDNSRecord:
     Type: AWS::Route53::RecordSet
@@ -90,6 +155,11 @@ Outputs:
     Value: !Ref ApplicationLoadBalancer
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancer'
+  ALBAccessLogsBucketArn:
+    Description: 'Application Load Balancer access logs output S3 bucket'
+    Value: !GetAtt ALBAccessLogsBucket.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBAccessLogsBucketArn'
   ALBListenerARN:
     Description: 'ARN of the ALB Listener'
     Value: !Ref ALBListener

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -27,11 +27,11 @@ Parameters:
 Mappings:
   ELBAccountsMap:
     us-east-1:
-      "ELBAccountRoot": "arn:aws:iam:127311923021:root"
+      "ELBAccountRoot": "arn:aws:iam::127311923021:root"
     us-west-2:
-      "ELBAccountRoot": "arn:aws:iam:797873946194:root"
+      "ELBAccountRoot": "arn:aws:iam::797873946194:root"
     us-west-1:
-      "ELBAccountRoot": "arn:aws:iam:027434742980:root"
+      "ELBAccountRoot": "arn:aws:iam::027434742980:root"
 
 Resources:
 
@@ -67,7 +67,8 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      BucketName: !Sub ${AWS::Region}-${AWS::StackName}-access
+#     BucketName: !Sub ${AWS::StackName}-weblogs
+      AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -76,6 +77,9 @@ Resources:
         Rules:
         - ExpirationInDays: 90
           Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
 
 # AWS required policy for writing ALB logs:
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
@@ -91,15 +95,13 @@ Resources:
             Principal:
               AWS: !FindInMap [ ELBAccountsMap, !Ref "AWS::Region", ELBAccountRoot ]
             Action: s3:PutObject
-            Resource:
-              - !Sub ${ALBAccessLogsBucket.Arn}/*
+            Resource: !Sub ${ALBAccessLogsBucket.Arn}/*
           - Sid: AllowAwsServiceWrite
             Effect: Allow
             Principal:
               Service: delivery.logs.amazonaws.com
             Action: s3:PutObject
-            Resource:
-              - !Sub ${ALBAccessLogsBucket.Arn}/*
+            Resource: !Sub ${ALBAccessLogsBucket.Arn}/*
             Condition:
               StringEquals:
                 s3:x-amz-acl: bucket-owner-full-control
@@ -108,8 +110,7 @@ Resources:
             Principal:
               Service: delivery.logs.amazonaws.com
             Action: s3:GetBucketAcl
-            Resource:
-              - !GetAtt ALBAccessLogsBucket.Arn
+            Resource: !GetAtt ALBAccessLogsBucket.Arn
 
   ApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -127,7 +128,7 @@ Resources:
         - Key: access_logs.s3.bucket
           Value: !Ref ALBAccessLogsBucket
         - Key: access_logs.s3.prefix
-          Value: !Join ['', [!Ref SubDomainName, ., !Ref DomainName, "-access"]]
+          Value: !Join ['', [!Ref SubDomainName, ., !Ref DomainName]]
 
   ConnectDNSRecord:
     Type: AWS::Route53::RecordSet


### PR DESCRIPTION
This PR adds the access logging service to the notebook-fronting ALB following [general AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html). I think we will actually want to forward these logs to logcentral, however.

This PR is revised based on a discussion today. This will allow us to log locally to the account for the time being. I've revised the bucket policy and path. 