### PR TITLE
[SC-100] update products

### DIFF
--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Notebook Linux EC2 ServiceCatalog product with Jumpcloud integration.'
+Description: 'Notebook Linux EC2 ServiceCatalog product '
 Parameters:
   RepoRootURL:
     Type: String
@@ -43,10 +43,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.2.yaml'
           Name: 'v1.0.2'
-        - Description: !Sub 'Adds alb-listener-rule custom resource, enabling connection outside VPN. Last updated at ${StackDatetime}'
+        - Description: !Sub 'Adds alb-listener-rule custom resource, enabling connection outside VPN'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.1/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.1'
+        - Description: !Sub 'Remove Jumpcloud Integration. Last updated at ${StackDatetime}'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.2/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+          Name: 'v1.1.2'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Notebook Linux EC2 ServiceCatalog product '
+Description: 'Notebook Linux EC2 ServiceCatalog product'
 Parameters:
   RepoRootURL:
     Type: String

--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -39,11 +39,11 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.1.yaml'
           Name: 'v1.0.1'
-        - Description: 'Fix to support multiple portfolios.'
+        - Description: 'Adds alb-listener-rule custom resource, enabling connection outside VPN'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.2.yaml'
           Name: 'v1.0.2'
-        - Description: !Sub 'Adds alb-listener-rule custom resource, enabling connection outside VPN'
+        - Description: 'Adds alb-listener-rule custom resource, enabling connection outside VPN'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.1/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.1'

--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -39,11 +39,11 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.1.yaml'
           Name: 'v1.0.1'
-        - Description: 'Adds alb-listener-rule custom resource, enabling connection outside VPN'
+        - Description: 'Fix to support multiple portfolios.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.2.yaml'
           Name: 'v1.0.2'
-        - Description: 'Add target group, alb listener rule-making custom resource, and new NotebookConnectionUri'
+        - Description: 'adds alb-listener-rule custom resource, enabling connection outside VPN.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.1/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.1'

--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -43,7 +43,7 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.2.yaml'
           Name: 'v1.0.2'
-        - Description: 'Adds alb-listener-rule custom resource, enabling connection outside VPN'
+        - Description: 'Add target group, alb listener rule-making custom resource, and new NotebookConnectionUri'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.1/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.1'

--- a/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Workflows Linux EC2 ServiceCatalog product with Jumpcloud integration.'
+Description: 'Workflows Linux EC2 ServiceCatalog product'
 Parameters:
   RepoRootURL:
     Type: String
@@ -39,10 +39,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.1.yaml'
           Name: 'v1.0.1'
-        - Description: !Sub 'Fix to support multiple portfolios. Last updated at ${StackDatetime}.'
+        - Description: !Sub 'Fix to support multiple portfolios'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.2.yaml'
           Name: 'v1.0.2'
+        - Description: !Sub 'Remove Jumpcloud Integration. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.2/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.2.yaml'
+          Name: 'v1.1.2'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -39,7 +39,7 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.1.yaml'
           Name: 'v1.0.1'
-        - Description: !Sub 'Fix to support multiple portfolios'
+        - Description: 'Fix to support multiple portfolios'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.2.yaml'
           Name: 'v1.0.2'

--- a/templates/sc-product-ec2-linux-jumpcloud.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud.yaml
@@ -38,7 +38,7 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-v1.0.1.yaml'
           Name: 'v1.0.1'
-        - Description: !Sub 'Fix to support multiple portfolios'
+        - Description: 'Fix to support multiple portfolios'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-v1.0.2.yaml'
           Name: 'v1.0.2'

--- a/templates/sc-product-ec2-linux-jumpcloud.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Linux EC2 ServiceCatalog product with Jumpcloud integration.
+Description: Linux EC2 ServiceCatalog product
 Parameters:
   RepoRootURL:
     Type: String
@@ -28,8 +28,7 @@ Resources:
             - W2001
     Properties:
       Name: !Ref ProductName
-      Description: This product builds one Linux EC2 instance, either
-        Amazon Linux or Ubuntu, with Jumpcloud integration.
+      Description: "This product builds one Linux EC2 instance, either Amazon Linux or Ubuntu"
       ProvisioningArtifactParameters:
         - Description: 'Baseline version.'
           Info:
@@ -39,10 +38,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/ec2/sc-ec2-linux-jumpcloud-v1.0.1.yaml'
           Name: 'v1.0.1'
-        - Description: !Sub 'Fix to support multiple portfolios. Last updated at ${StackDatetime}.'
+        - Description: !Sub 'Fix to support multiple portfolios'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-v1.0.2.yaml'
           Name: 'v1.0.2'
+        - Description: !Sub 'Remove Jumpcloud Integration. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.2/ec2/sc-ec2-linux-jumpcloud-v1.0.2.yaml'
+          Name: 'v1.1.2'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:


### PR DESCRIPTION
Update products without jumpcloud integration.  The only product
that still contains jumpcloud integration is windows EC2.

depends on https://github.com/Sage-Bionetworks/service-catalog-library/pull/216
and a new v1.1.2 tag