### PR TITLE
[SC-215] Target tag option values

### DIFF
--- a/config/develop/sc-tag-options-external.yaml
+++ b/config/develop/sc-tag-options-external.yaml
@@ -1,0 +1,17 @@
+template_path: "sc-tag-options-external.j2"
+stack_name: "sc-tag-options-external"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "develop/sc-portfolio-ec2.yaml"
+  - "develop/sc-portfolio-ec2-external.yaml"
+  - "develop/sc-portfolio-s3-basic.yaml"
+sceptre_user_data:
+  Departments:
+    - "sage-external"
+  Projects:
+    - "collaborator"
+  ProductIDs:
+    - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/config/develop/sc-tag-options.yaml
+++ b/config/develop/sc-tag-options.yaml
@@ -28,5 +28,4 @@ sceptre_user_data:
     - "pson"
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
-    - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/config/prod/sc-tag-options-external.yaml
+++ b/config/prod/sc-tag-options-external.yaml
@@ -1,0 +1,17 @@
+template_path: "sc-tag-options-external.j2"
+stack_name: "sc-tag-options-external"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/sc-portfolio-ec2.yaml"
+  - "prod/sc-portfolio-ec2-external.yaml"
+  - "prod/sc-portfolio-s3-basic.yaml"
+sceptre_user_data:
+  Departments:
+    - "sage-external"
+  Projects:
+    - "collaborator"
+  ProductIDs:
+    - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/config/prod/sc-tag-options.yaml
+++ b/config/prod/sc-tag-options.yaml
@@ -28,5 +28,4 @@ sceptre_user_data:
     - "pson"
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
-    - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId


### PR DESCRIPTION
We've decided that keeping tag options consistant for internal
and external users would simplify management of tags.
However we also want to distinguise what values are available to
external vs internal users. This PR targets tag option
values, external users will be required to set the Department
and Project tag however we will only allow one value for each
tag.