### PR TITLE
Add DependsOn statement to ALB resource

### DIFF
--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -113,6 +113,7 @@ Resources:
 
   ApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    DependsOn: ALBAccessLogsBucketPolicy
     Properties:
       Scheme: internet-facing
       Subnets:


### PR DESCRIPTION
I believe cfn deployment fails sometimes because the logging bucket is not ready with the policy that allows the ELB service to check access control. This should make the relationship explicit.