### PR TITLE
Revert "SC-211/alb attributes"

### DIFF
--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -1,8 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
-dependencies:
-  alb-notebook-access-logsbucket
 parameters:
   DomainName: "scipooldev.org"
   SubDomainName: "connect"

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -63,14 +63,6 @@ Resources:
       - !Ref VpcPublicSubnetC
       SecurityGroups:
       - !Ref ALBSecurityGroup
-      LoadBalancerAttributes:
-        - Key: access_logs.s3.enabled
-          Value: 'true'
-        - Key: access_logs.s3.bucket
-          Value: !ImportValue
-            'Fn::Sub': '${AWS::Region}-${AWS::StackName}-logsbucket-ALBAccessLogsBucket'
-        - Key: access_logs.s3.prefix
-          Value: !Join ['', [!Ref SubDomainName, ., !Ref DomainName]]
 
   ConnectDNSRecord:
     Type: AWS::Route53::RecordSet


### PR DESCRIPTION
Reverts Sage-Bionetworks/scipool-infra#159

The sceptre config for `alb-notebook-access-logsbucket` is malformed