### PR TITLE
Sceptre templates were malformed

### DIFF
--- a/config/develop/alb-notebook-access-logsbucket.yaml
+++ b/config/develop/alb-notebook-access-logsbucket.yaml
@@ -1,3 +1,2 @@
-AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access-logsbucket.yaml
 stack_name: alb-notebook-access-logsbucket

--- a/config/prod/alb-notebook-access-logsbucket.yaml
+++ b/config/prod/alb-notebook-access-logsbucket.yaml
@@ -1,3 +1,2 @@
-AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access-logsbucket.yaml
 stack_name: alb-notebook-access-logsbucket


### PR DESCRIPTION
Somehow the prior PR had a cfn header in a sceptre template. This fixes the deployment on top of a failing build.