### PR TITLE
Revised malformed sceptre config

### DIFF
--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -1,8 +1,7 @@
-AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 dependencies:
-  alb-notebook-access-logsbucket
+  - develop/alb-notebook-access-logsbucket.yaml
 parameters:
   DomainName: "scipooldev.org"
   SubDomainName: "connect"

--- a/config/prod/alb-notebook-access.yaml
+++ b/config/prod/alb-notebook-access.yaml
@@ -1,6 +1,7 @@
-AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
+dependencies:
+  - prod/alb-notebook-access-logsbucket.yaml
 parameters:
   DomainName: "scipoolprod.org"
   SubDomainName: "connect"


### PR DESCRIPTION
The travis build is still failing because of a broken sceptre template from a different branch. This PR should fix.