### PR TITLE
Update from develop to prod

### DIFF
--- a/config/develop/alb-notebook-access-logsbucket.yaml
+++ b/config/develop/alb-notebook-access-logsbucket.yaml
@@ -1,0 +1,3 @@
+AWSTemplateFormatVersion: 2010-09-09
+template_path: alb-notebook-access-logsbucket.yaml
+stack_name: alb-notebook-access-logsbucket

--- a/config/develop/alb-notebook-access-logsbucket.yaml
+++ b/config/develop/alb-notebook-access-logsbucket.yaml
@@ -1,3 +1,2 @@
-AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access-logsbucket.yaml
 stack_name: alb-notebook-access-logsbucket

--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -1,8 +1,7 @@
-AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
 dependencies:
-  alb-notebook-access-logsbucket
+  - develop/alb-notebook-access-logsbucket.yaml
 parameters:
   DomainName: "scipooldev.org"
   SubDomainName: "connect"

--- a/config/develop/alb-notebook-access.yaml
+++ b/config/develop/alb-notebook-access.yaml
@@ -1,6 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
+dependencies:
+  alb-notebook-access-logsbucket
 parameters:
   DomainName: "scipooldev.org"
   SubDomainName: "connect"

--- a/config/develop/sc-tag-options-external.yaml
+++ b/config/develop/sc-tag-options-external.yaml
@@ -1,3 +1,4 @@
+# Tag options for External Sage teams
 template_path: "sc-tag-options.j2"
 stack_name: "sc-tag-options-external"
 stack_tags:

--- a/config/develop/sc-tag-options-external.yaml
+++ b/config/develop/sc-tag-options-external.yaml
@@ -1,4 +1,4 @@
-template_path: "sc-tag-options-external.j2"
+template_path: "sc-tag-options.j2"
 stack_name: "sc-tag-options-external"
 stack_tags:
   Department: "Platform"

--- a/config/develop/sc-tag-options-external.yaml
+++ b/config/develop/sc-tag-options-external.yaml
@@ -1,0 +1,17 @@
+template_path: "sc-tag-options-external.j2"
+stack_name: "sc-tag-options-external"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "develop/sc-portfolio-ec2.yaml"
+  - "develop/sc-portfolio-ec2-external.yaml"
+  - "develop/sc-portfolio-s3-basic.yaml"
+sceptre_user_data:
+  Departments:
+    - "sage-external"
+  Projects:
+    - "collaborator"
+  ProductIDs:
+    - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/config/develop/sc-tag-options.yaml
+++ b/config/develop/sc-tag-options.yaml
@@ -1,3 +1,4 @@
+# Tag options for internal Sage teams
 template_path: "sc-tag-options.j2"
 stack_name: "sc-tag-options"
 stack_tags:

--- a/config/develop/sc-tag-options.yaml
+++ b/config/develop/sc-tag-options.yaml
@@ -28,5 +28,4 @@ sceptre_user_data:
     - "pson"
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
-    - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/config/prod/alb-notebook-access-logsbucket.yaml
+++ b/config/prod/alb-notebook-access-logsbucket.yaml
@@ -1,0 +1,3 @@
+AWSTemplateFormatVersion: 2010-09-09
+template_path: alb-notebook-access-logsbucket.yaml
+stack_name: alb-notebook-access-logsbucket

--- a/config/prod/alb-notebook-access-logsbucket.yaml
+++ b/config/prod/alb-notebook-access-logsbucket.yaml
@@ -1,3 +1,2 @@
-AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access-logsbucket.yaml
 stack_name: alb-notebook-access-logsbucket

--- a/config/prod/alb-notebook-access.yaml
+++ b/config/prod/alb-notebook-access.yaml
@@ -1,6 +1,7 @@
-AWSTemplateFormatVersion: 2010-09-09
 template_path: alb-notebook-access.yaml
 stack_name: alb-notebook-access
+dependencies:
+  - prod/alb-notebook-access-logsbucket.yaml
 parameters:
   DomainName: "scipoolprod.org"
   SubDomainName: "connect"

--- a/config/prod/sc-tag-options-external.yaml
+++ b/config/prod/sc-tag-options-external.yaml
@@ -1,3 +1,4 @@
+# Tag options for External Sage teams
 template_path: "sc-tag-options.j2"
 stack_name: "sc-tag-options-external"
 stack_tags:

--- a/config/prod/sc-tag-options-external.yaml
+++ b/config/prod/sc-tag-options-external.yaml
@@ -1,4 +1,4 @@
-template_path: "sc-tag-options-external.j2"
+template_path: "sc-tag-options.j2"
 stack_name: "sc-tag-options-external"
 stack_tags:
   Department: "Platform"

--- a/config/prod/sc-tag-options-external.yaml
+++ b/config/prod/sc-tag-options-external.yaml
@@ -1,0 +1,17 @@
+template_path: "sc-tag-options-external.j2"
+stack_name: "sc-tag-options-external"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/sc-portfolio-ec2.yaml"
+  - "prod/sc-portfolio-ec2-external.yaml"
+  - "prod/sc-portfolio-s3-basic.yaml"
+sceptre_user_data:
+  Departments:
+    - "sage-external"
+  Projects:
+    - "collaborator"
+  ProductIDs:
+    - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/config/prod/sc-tag-options.yaml
+++ b/config/prod/sc-tag-options.yaml
@@ -1,3 +1,4 @@
+# Tag options for internal Sage teams
 template_path: "sc-tag-options.j2"
 stack_name: "sc-tag-options"
 stack_tags:

--- a/config/prod/sc-tag-options.yaml
+++ b/config/prod/sc-tag-options.yaml
@@ -28,5 +28,4 @@ sceptre_user_data:
     - "pson"
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
-    - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/templates/alb-notebook-access-logsbucket.yaml
+++ b/templates/alb-notebook-access-logsbucket.yaml
@@ -1,0 +1,74 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Create ALB that can be modified by Service Catalog provisioning requests
+
+Mappings:
+  ELBAccountsMap:
+    us-east-1:
+      "ELBAccountRoot": "arn:aws:iam::127311923021:root"
+    us-west-2:
+      "ELBAccountRoot": "arn:aws:iam::797873946194:root"
+    us-west-1:
+      "ELBAccountRoot": "arn:aws:iam::027434742980:root"
+
+Resources:
+
+  ALBAccessLogsBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      AccessControl: Private
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+        - ExpirationInDays: 90
+          Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
+
+# AWS required policy for writing ALB logs:
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+  ALBAccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ALBAccessLogsBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowALBAccountWrite
+            Effect: Allow
+            Principal:
+              AWS: !FindInMap [ ELBAccountsMap, !Ref "AWS::Region", ELBAccountRoot ]
+            Action: s3:PutObject
+            Resource: !Sub ${ALBAccessLogsBucket.Arn}/*
+          - Sid: AllowAwsServiceWrite
+            Effect: Allow
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub ${ALBAccessLogsBucket.Arn}/*
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+          - Sid: AllowAwsServiceAclCheck
+            Effect: Allow
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt ALBAccessLogsBucket.Arn
+
+Outputs:
+  ALBAccessLogsBucket:
+    Description: 'Application Load Balancer access logs output S3 bucket'
+    Value: !Ref ALBAccessLogsBucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBAccessLogsBucket'
+  ALBAccessLogsBucketArn:
+    Description: 'Application Load Balancer access logs output S3 bucket ARN'
+    Value: !GetAtt ALBAccessLogsBucket.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBAccessLogsBucketArn'

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -24,6 +24,15 @@ Parameters:
     Description: 'ARN for a certificate that exists in the account and is valid for the domain'
     Type: String
 
+Mappings:
+  ELBAccountsMap:
+    us-east-1:
+      "ELBAccountRoot": "arn:aws:iam::127311923021:root"
+    us-west-2:
+      "ELBAccountRoot": "arn:aws:iam::797873946194:root"
+    us-west-1:
+      "ELBAccountRoot": "arn:aws:iam::027434742980:root"
+
 Resources:
 
   ALBSecurityGroup:
@@ -53,6 +62,55 @@ Resources:
       Port: 443
       Protocol: HTTPS
 
+  ALBAccessLogsBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      AccessControl: Private
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+        - ExpirationInDays: 90
+          Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
+
+# AWS required policy for writing ALB logs:
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+  ALBAccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ALBAccessLogsBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowALBAccountWrite
+            Effect: Allow
+            Principal:
+              AWS: !FindInMap [ ELBAccountsMap, !Ref "AWS::Region", ELBAccountRoot ]
+            Action: s3:PutObject
+            Resource: !Sub ${ALBAccessLogsBucket.Arn}/*
+          - Sid: AllowAwsServiceWrite
+            Effect: Allow
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub ${ALBAccessLogsBucket.Arn}/*
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+          - Sid: AllowAwsServiceAclCheck
+            Effect: Allow
+            Principal:
+              Service: delivery.logs.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt ALBAccessLogsBucket.Arn
+
   ApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -63,6 +121,13 @@ Resources:
       - !Ref VpcPublicSubnetC
       SecurityGroups:
       - !Ref ALBSecurityGroup
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: 'true'
+        - Key: access_logs.s3.bucket
+          Value: !Ref ALBAccessLogsBucket
+        - Key: access_logs.s3.prefix
+          Value: !Join ['', [!Ref SubDomainName, ., !Ref DomainName]]
 
   ConnectDNSRecord:
     Type: AWS::Route53::RecordSet
@@ -90,6 +155,11 @@ Outputs:
     Value: !Ref ApplicationLoadBalancer
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancer'
+  ALBAccessLogsBucketArn:
+    Description: 'Application Load Balancer access logs output S3 bucket'
+    Value: !GetAtt ALBAccessLogsBucket.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBAccessLogsBucketArn'
   ALBListenerARN:
     Description: 'ARN of the ALB Listener'
     Value: !Ref ALBListener

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -63,6 +63,14 @@ Resources:
       - !Ref VpcPublicSubnetC
       SecurityGroups:
       - !Ref ALBSecurityGroup
+      LoadBalancerAttributes:
+        - Key: access_logs.s3.enabled
+          Value: 'true'
+        - Key: access_logs.s3.bucket
+          Value: !ImportValue
+            'Fn::Sub': '${AWS::Region}-${AWS::StackName}-logsbucket-ALBAccessLogsBucket'
+        - Key: access_logs.s3.prefix
+          Value: !Join ['', [!Ref SubDomainName, ., !Ref DomainName]]
 
   ConnectDNSRecord:
     Type: AWS::Route53::RecordSet

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -24,15 +24,6 @@ Parameters:
     Description: 'ARN for a certificate that exists in the account and is valid for the domain'
     Type: String
 
-Mappings:
-  ELBAccountsMap:
-    us-east-1:
-      "ELBAccountRoot": "arn:aws:iam::127311923021:root"
-    us-west-2:
-      "ELBAccountRoot": "arn:aws:iam::797873946194:root"
-    us-west-1:
-      "ELBAccountRoot": "arn:aws:iam::027434742980:root"
-
 Resources:
 
   ALBSecurityGroup:
@@ -62,55 +53,6 @@ Resources:
       Port: 443
       Protocol: HTTPS
 
-  ALBAccessLogsBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    Properties:
-      AccessControl: Private
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      LifecycleConfiguration:
-        Rules:
-        - ExpirationInDays: 90
-          Status: Enabled
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: True
-        BlockPublicPolicy: True
-
-# AWS required policy for writing ALB logs:
-# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
-  ALBAccessLogsBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref ALBAccessLogsBucket
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AllowALBAccountWrite
-            Effect: Allow
-            Principal:
-              AWS: !FindInMap [ ELBAccountsMap, !Ref "AWS::Region", ELBAccountRoot ]
-            Action: s3:PutObject
-            Resource: !Sub ${ALBAccessLogsBucket.Arn}/*
-          - Sid: AllowAwsServiceWrite
-            Effect: Allow
-            Principal:
-              Service: delivery.logs.amazonaws.com
-            Action: s3:PutObject
-            Resource: !Sub ${ALBAccessLogsBucket.Arn}/*
-            Condition:
-              StringEquals:
-                s3:x-amz-acl: bucket-owner-full-control
-          - Sid: AllowAwsServiceAclCheck
-            Effect: Allow
-            Principal:
-              Service: delivery.logs.amazonaws.com
-            Action: s3:GetBucketAcl
-            Resource: !GetAtt ALBAccessLogsBucket.Arn
-
   ApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -121,13 +63,6 @@ Resources:
       - !Ref VpcPublicSubnetC
       SecurityGroups:
       - !Ref ALBSecurityGroup
-      LoadBalancerAttributes:
-        - Key: access_logs.s3.enabled
-          Value: 'true'
-        - Key: access_logs.s3.bucket
-          Value: !Ref ALBAccessLogsBucket
-        - Key: access_logs.s3.prefix
-          Value: !Join ['', [!Ref SubDomainName, ., !Ref DomainName]]
 
   ConnectDNSRecord:
     Type: AWS::Route53::RecordSet
@@ -155,11 +90,6 @@ Outputs:
     Value: !Ref ApplicationLoadBalancer
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-ApplicationLoadBalancer'
-  ALBAccessLogsBucketArn:
-    Description: 'Application Load Balancer access logs output S3 bucket'
-    Value: !GetAtt ALBAccessLogsBucket.Arn
-    Export:
-      Name: !Sub '${AWS::Region}-${AWS::StackName}-ALBAccessLogsBucketArn'
   ALBListenerARN:
     Description: 'ARN of the ALB Listener'
     Value: !Ref ALBListener


### PR DESCRIPTION
Changes:

2eec777 (Khai Do, 2 minutes ago)
   add comments to tag option deployments (#164)

e40fc02 (Khai Do, 12 minutes ago)
   fix file reference (#163)

4e62d3e (Khai Do, 49 minutes ago)
   Target tag option values (#154)

   We've decided that keeping tag options consistant for internal and
   external users would simplify management of tags. However we also want to
   distinguise what values are available to external vs internal users. This
   PR targets tag option values, external users will be required to set the
   Department and Project tag however we will only allow one value for each 
   tag.
6817c1b (Aaron Hayden, 30 hours ago)
   Revised malformed sceptre config

c3163b0 (Aaron Hayden, 3 days ago)
   Sceptre templates were malformed

51fd678 (Aaron Hayden, 3 days ago)
   Add logsbucket template to prod sceptre config

c32469e (Aaron Hayden, 4 days ago)
   Fix lint error

797ae53 (Aaron Hayden, 4 days ago)
   Remove export and sceptre config for other branch

a7cc42a (Aaron Hayden, 4 days ago)
   Remove parameters

8ac9898 (Aaron Hayden, 4 days ago)
   Split ALB logging into two templates

efa5fee (Aaron Hayden, 4 days ago)
   Split logging into two templates

41cdcda (Aaron Hayden, 4 days ago)
   Revert "Add ALB logging within account"

7841201 (Aaron Hayden, 4 days ago)
   Add DependsOn statement to ALB resource

b75edc4 (Aaron Hayden, 4 days ago)
   Remove comment

32a8eea (Aaron Hayden, 5 days ago)
   Revise logging path and bucket permissions

b1015cd (Aaron Hayden, 10 days ago)
   Add ALB logging within account