### PR TITLE
[SC-219] Fix SC action associations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ install:
   - pip install pre-commit sceptre sceptre-ssm-resolver sceptre-date-resolver
 stages:
   - name: validate
-  - name: disassociate-sc-actions
-    if: type = push AND branch = develop
   - name: deploy
     if: type = push
 jobs:
@@ -23,9 +21,8 @@ jobs:
       script:
         - pre-commit autoupdate
         - pre-commit run --all-files
-    - stage: disassociate-sc-actions
-      script:
-        - sceptre delete $TRAVIS_BRANCH/sc-product-assoc-ec2 --yes
     - stage: deploy
       script:
+        # SC-26 & SC-219 workaround: dis-associate and re-associate SC actions on every deploy
+        - sceptre delete $TRAVIS_BRANCH/sc-product-assoc-ec2 --yes
         - sceptre launch $TRAVIS_BRANCH --yes


### PR DESCRIPTION
We set the "ReplaceProvisioningArtifacts" to false for the SC prod env
to prevent new product IDs from being created on every deployment which
is what we want. Since product IDs never change the template to associate
SC actions to products never runs on subsequent stack updates. This is
the reason why SC actions don't appear on newly added versions of a
SC product.

To fix this we need to dis-associate and re-associate SC actions on every
deployment.  This strategy is a work around for issue SC-26

Note: The dis-association will remove SC actions from the SC actions
menu for a short period of time.  This can cause 2 issues for the user:
1. user cannot access stop/start/restart because it has been
   dis-associated before they clicked on the SC actions menu.
   This is momentary because the re-association shoule add it back.
2. user click on stop/start/restart actions right before it gets
   dis-associated from the product.  In this case the user will get an
   error from the SC.  Again this is mometary because the re-associate
   whould provide the functionality again.

The issues noted above will only appear when there is a new deployment for updates.