### PR TITLE
[SC-88] Add lambda-budgets configuration

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,2 @@
+ignore_templates:
+  - templates/**/lambda-budgets/*.yaml

--- a/config/develop/lambda-budgets.yaml
+++ b/config/develop/lambda-budgets.yaml
@@ -1,0 +1,14 @@
+template_path: remote/lambda-budgets.yaml
+stack_name: lambda-budgets
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+parameters:
+  SynapseTeamMemberListEndpoint: 'https://repo-prod.prod.sagebase.org/repo/v1/teamMembers'
+  EndUserRoleName: !stack_output_external sc-enduser-iam::EndUserRoleName
+  BudgetRules: !file_contents templates/develop/lambda-budgets/budget-rules.yaml
+  Thresholds: !file_contents templates/develop/lambda-budgets/thresholds.yaml
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml --create-dirs -o templates/remote/lambda-budgets.yaml"

--- a/config/prod/lambda-budgets.yaml
+++ b/config/prod/lambda-budgets.yaml
@@ -1,0 +1,14 @@
+template_path: remote/lambda-budgets.yaml
+stack_name: lambda-budgets
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+parameters:
+  SynapseTeamMemberListEndpoint: 'https://repo-prod.prod.sagebase.org/repo/v1/teamMembers'
+  EndUserRoleName: !stack_output_external sc-enduser-iam::ExternalEndUserRoleName
+  BudgetRules: !file_contents templates/prod/lambda-budgets/budget-rules.yaml
+  Thresholds: !file_contents templates/prod/lambda-budgets/thresholds.yaml
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/lambda-budgets/master/lambda-budgets.yaml --create-dirs -o templates/remote/lambda-budgets.yaml"

--- a/templates/develop/lambda-budgets/budget-rules.yaml
+++ b/templates/develop/lambda-budgets/budget-rules.yaml
@@ -1,0 +1,7 @@
+# budget rules per user by synapse team id
+teams:
+  '3412821':
+    amount: '10'
+    period: ANNUALLY
+    unit: USD
+    community_manager_emails: ['someone@example.org']

--- a/templates/develop/lambda-budgets/thresholds.yaml
+++ b/templates/develop/lambda-budgets/thresholds.yaml
@@ -1,0 +1,8 @@
+notify_user_only:
+  - 25.0
+  - 50.0
+  - 80.0
+notify_admins_too:
+  - 90.0
+  - 100.0
+  - 110.0

--- a/templates/prod/lambda-budgets/budget-rules.yaml
+++ b/templates/prod/lambda-budgets/budget-rules.yaml
@@ -1,0 +1,14 @@
+# budget rules per user by synapse team id
+teams:
+  '3412678': # AMPAD_WG_ServiceCatalogUsers
+    amount: '2000'
+    period: ANNUALLY
+    unit: USD
+    community_manager_emails:
+      - 'sc-support@sagebase.org'
+  '3412679': # ADPortal_ServiceCatalogUsers
+    amount: '100'
+    period: ANNUALLY
+    unit: USD
+    community_manager_emails:
+      - 'sc-support@sagebase.org'

--- a/templates/prod/lambda-budgets/thresholds.yaml
+++ b/templates/prod/lambda-budgets/thresholds.yaml
@@ -1,0 +1,8 @@
+notify_user_only:
+  - 25.0
+  - 50.0
+  - 80.0
+notify_admins_too:
+  - 90.0
+  - 100.0
+  - 110.0


### PR DESCRIPTION
This adds the lambda-budgets configuration for dev and prod. It depends on a new folder, "budgets", which contains configuration files for the lambda. The role in the configurations in different for dev and prod deliberately.

Depends on https://github.com/Sage-Bionetworks-IT/lambda-budgets/pull/5