### PR TITLE
Update effected templates to service-catalog-library v1.1.3

### DIFF
--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -47,10 +47,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.1/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.1'
-        - Description: !Sub 'Remove Jumpcloud Integration. Last updated at ${StackDatetime}'
+        - Description: 'Remove Jumpcloud Integration.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.2/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.2'
+        - Description: !Sub 'Update Cloudformation hooks. Last updated at ${StackDatetime}'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+          Name: 'v1.1.3'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -43,10 +43,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.2.yaml'
           Name: 'v1.0.2'
-        - Description: !Sub 'Remove Jumpcloud Integration. Last updated at ${StackDatetime}.'
+        - Description: 'Remove Jumpcloud Integration.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.2/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
           Name: 'v1.1.2'
+        - Description: !Sub 'Update Cloudformation hooks. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
+          Name: 'v1.1.3'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-linux-jumpcloud.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud.yaml
@@ -42,10 +42,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.2/ec2/sc-ec2-linux-jumpcloud-v1.0.2.yaml'
           Name: 'v1.0.2'
-        - Description: !Sub 'Remove Jumpcloud Integration. Last updated at ${StackDatetime}.'
+        - Description: 'Remove Jumpcloud Integration.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.2/ec2/sc-ec2-linux-jumpcloud.yaml'
           Name: 'v1.1.2'
+        - Description: !Sub 'Update Cloudformation hooks. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-linux-jumpcloud.yaml'
+          Name: 'v1.1.3'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-windows-jumpcloud.yaml
+++ b/templates/sc-product-ec2-windows-jumpcloud.yaml
@@ -31,10 +31,14 @@ Resources:
       Description: This product builds one Microsoft Windows EC2 instance with
         Jumpcloud integration.
       ProvisioningArtifactParameters:
-        - Description: !Sub 'Baseline version. Last updated at ${StackDatetime}.'
+        - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml'
           Name: 'v1.0.0'
+        - Description: !Sub 'Update base AMI and Cloudformation hooks. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml'
+          Name: 'v1.1.3'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:


### PR DESCRIPTION
This updates EC2 templates to use `service-catalog-library v1.1.3` which includes:
- Cfn signaling so products announce ready only when building is fully done
- Updated Windows Server 2016 AMI ID

Passes pre-commit
