### PR TITLE
Change file path on Windows products

### DIFF
--- a/templates/sc-product-ec2-windows-jumpcloud.yaml
+++ b/templates/sc-product-ec2-windows-jumpcloud.yaml
@@ -37,7 +37,7 @@ Resources:
           Name: 'v1.0.0'
         - Description: !Sub 'Update base AMI and Cloudformation hooks. Last updated at ${StackDatetime}.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-windows-jumpcloud.yaml'
           Name: 'v1.1.3'
       'Fn::Transform':
         Name: 'AWS::Include'


### PR DESCRIPTION
We had removed version strings from product filepaths, but had not released a new version of the Windows product. This corrects the filepath name that broke the build.

Passes pre-commit.