### PR TITLE
[SC-226] Add iam:TagRole permission to launch policies

### DIFF
--- a/templates/sc-ec2vpc-launchrole.yaml
+++ b/templates/sc-ec2vpc-launchrole.yaml
@@ -41,6 +41,7 @@ Resources:
                   - "iam:CreateRole"
                   - "iam:DetachRolePolicy"
                   - "iam:AttachRolePolicy"
+                  - "iam:TagRole"
                   - "cloudformation:DescribeStackResource"
                   - "cloudformation:DescribeStackResources"
                   - "cloudformation:GetTemplate"

--- a/templates/sc-s3-launchrole.yaml
+++ b/templates/sc-s3-launchrole.yaml
@@ -37,6 +37,7 @@ Resources:
                   - "iam:CreateRole"
                   - "iam:DetachRolePolicy"
                   - "iam:AttachRolePolicy"
+                  - "iam:TagRole"
                   - "cloudformation:DescribeStackResource"
                   - "cloudformation:DescribeStackResources"
                   - "cloudformation:GetTemplate"


### PR DESCRIPTION
SC launch of workflows product is failing because the launch roles are missing the ability to tag IAM roles, so add that permission to relevant policies.
