### PR TITLE
IT-957: Add VPC gateway endpoints

### DIFF
--- a/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
+++ b/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
@@ -1,7 +1,7 @@
 template_path: remote/gateway-vpc-endpoint.yaml
 stack_name: s3-cesspoolvpc-gateway-endpoint
 dependencies:
-  - prod/cesspoolvpc.yaml
+  - develop/cesspoolvpc.yaml
 parameters:
   VpcName: cesspoolvpc
   ServiceName: com.amazonaws.us-east-1.s3

--- a/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
+++ b/config/develop/s3-cesspoolvpc-gateway-endpoint.yaml
@@ -1,0 +1,10 @@
+template_path: remote/gateway-vpc-endpoint.yaml
+stack_name: s3-cesspoolvpc-gateway-endpoint
+dependencies:
+  - prod/cesspoolvpc.yaml
+parameters:
+  VpcName: cesspoolvpc
+  ServiceName: com.amazonaws.us-east-1.s3
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"

--- a/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
+++ b/config/prod/s3-internalpoolvpc-gateway-endpoint.yaml
@@ -1,0 +1,10 @@
+template_path: remote/gateway-vpc-endpoint.yaml
+stack_name: s3-internalpoolvpc-gateway-endpoint
+dependencies:
+  - prod/internalpoolvpc.yaml
+parameters:
+  VpcName: internalpoolvpc
+  ServiceName: com.amazonaws.us-east-1.s3
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"


### PR DESCRIPTION
[IT-957]
This PR adds VPC gateway endpoints in cesspoolvpc and internalpoolvpc. This should ensure that we don't incur NAT charges when pushing data from EC2 instances in these VPCs to S3.


[IT-957]: https://sagebionetworks.jira.com/browse/IT-957