### PR TITLE
[SC-190] Update SC libraries

### DIFF
--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -31,6 +31,8 @@ Resources:
       Description: This product builds one Linux EC2 instance using an Rstudio
         AMI based on Ubuntu and maintained by Sage Bionetworks.
       ProvisioningArtifactParameters:
+        # StackDatetime is used to force this template to pick updated nested stack code.  Add it to
+        # the description to force cloudformation to update the stack with the latest code.
         - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml'

--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -51,10 +51,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.2/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.2'
-        - Description: !Sub 'Update Cloudformation hooks. Last updated at ${StackDatetime}'
+        - Description: 'Update Cloudformation hooks'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.3'
+        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+          Name: 'v1.1.7'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -31,6 +31,8 @@ Resources:
       Description: This product builds one Linux EC2 instance using an Ubuntu AMI
         with workflows software installed. Maintained by Sage Bionetworks.
       ProvisioningArtifactParameters:
+        # StackDatetime is used to force this template to pick updated nested stack code.  Add it to
+        # the description to force cloudformation to update the stack with the latest code.
         - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml'

--- a/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -55,10 +55,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.4/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
           Name: 'v1.1.4'
-        - Description: !Sub 'Add ssm-user before adding to docker group. Last updated at ${StackDatetime}.'
+        - Description: 'Add ssm-user before adding to docker group'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.5/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
           Name: 'v1.1.5'
+        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
+          Name: 'v1.1.7'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-linux-jumpcloud.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud.yaml
@@ -30,6 +30,8 @@ Resources:
       Name: !Ref ProductName
       Description: "This product builds one Linux EC2 instance, either Amazon Linux or Ubuntu"
       ProvisioningArtifactParameters:
+        # StackDatetime is used to force this template to pick updated nested stack code.  Add it to
+        # the description to force cloudformation to update the stack with the latest code.
         - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml'

--- a/templates/sc-product-ec2-linux-jumpcloud.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud.yaml
@@ -46,10 +46,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.2/ec2/sc-ec2-linux-jumpcloud.yaml'
           Name: 'v1.1.2'
-        - Description: !Sub 'Update Cloudformation hooks. Last updated at ${StackDatetime}.'
+        - Description: 'Update Cloudformation hooks'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-linux-jumpcloud.yaml'
           Name: 'v1.1.3'
+        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/ec2/sc-ec2-linux-jumpcloud.yaml'
+          Name: 'v1.1.7'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-windows-jumpcloud.yaml
+++ b/templates/sc-product-ec2-windows-jumpcloud.yaml
@@ -31,6 +31,8 @@ Resources:
       Description: This product builds one Microsoft Windows EC2 instance with
         Jumpcloud integration.
       ProvisioningArtifactParameters:
+        # StackDatetime is used to force this template to pick updated nested stack code.  Add it to
+        # the description to force cloudformation to update the stack with the latest code.
         - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml'

--- a/templates/sc-product-ec2-windows-jumpcloud.yaml
+++ b/templates/sc-product-ec2-windows-jumpcloud.yaml
@@ -39,6 +39,10 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-windows-jumpcloud.yaml'
           Name: 'v1.1.3'
+        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/ec2/sc-ec2-windows-jumpcloud.yaml'
+          Name: 'v1.1.7'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-s3-private-enc.yaml
+++ b/templates/sc-product-s3-private-enc.yaml
@@ -35,6 +35,10 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/s3/sc-s3-encrypted-ra-v1.0.1.yaml'
           Name: 'v1.0.1'
+        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/s3/sc-s3-encrypted-ra.yaml'
+          Name: 'v1.1.7'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-s3-private-enc.yaml
+++ b/templates/sc-product-s3-private-enc.yaml
@@ -27,6 +27,8 @@ Resources:
       Description: This product builds an AWS S3 bucket encrypted with private
         access accessible from any source.
       ProvisioningArtifactParameters:
+        # StackDatetime is used to force this template to pick updated nested stack code.  Add it to
+        # the description to force cloudformation to update the stack with the latest code.
         - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/s3/sc-s3-encrypted-ra-v1.0.0.yaml'

--- a/templates/sc-product-s3-synapse.yaml
+++ b/templates/sc-product-s3-synapse.yaml
@@ -27,6 +27,8 @@ Resources:
       Description: This product builds an AWS S3 bucket with private access
         for Synapse.
       ProvisioningArtifactParameters:
+        # StackDatetime is used to force this template to pick updated nested stack code.  Add it to
+        # the description to force cloudformation to update the stack with the latest code.
         - Description: 'Baseline version.'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.0/s3/sc-s3-synapse-ra-v1.0.0.yaml'

--- a/templates/sc-product-s3-synapse.yaml
+++ b/templates/sc-product-s3-synapse.yaml
@@ -43,6 +43,10 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.6/s3/sc-s3-synapse-ra.yaml'
           Name: 'v1.1.6'
+        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/s3/sc-s3-synapse-ra.yaml'
+          Name: 'v1.1.7'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:


### PR DESCRIPTION
Updte SC libraries to use the cfn-cr-synapse-tagger custom resource[1]

[1] https://github.com/Sage-Bionetworks-IT/cfn-cr-synapse-tagger

depends on Sage-Bionetworks/service-catalog-library#225

also depends on creating a Sage-Bionetworks/service-catalog-library `v1.1.7` tag 