### PR TITLE
[SC-207] Update SC libraries

### DIFF
--- a/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -57,10 +57,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.3'
-        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+        - Description: 'Use SynapseTagger'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
           Name: 'v1.1.7'
+        - Description: !Sub 'Add a synapse teamId tag. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.8/ec2/sc-ec2-linux-jumpcloud-notebook.yaml'
+          Name: 'v1.1.8'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -61,10 +61,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.5/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
           Name: 'v1.1.5'
-        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+        - Description: 'Use SynapseTagger'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
           Name: 'v1.1.7'
+        - Description: !Sub 'Add a synapse teamId tag. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.8/ec2/sc-ec2-linux-jumpcloud-workflows.yaml'
+          Name: 'v1.1.8'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-linux-jumpcloud.yaml
+++ b/templates/sc-product-ec2-linux-jumpcloud.yaml
@@ -52,10 +52,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-linux-jumpcloud.yaml'
           Name: 'v1.1.3'
-        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+        - Description: 'Use SynapseTagger'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/ec2/sc-ec2-linux-jumpcloud.yaml'
           Name: 'v1.1.7'
+        - Description: !Sub 'Add a synapse teamId tag. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.8/ec2/sc-ec2-linux-jumpcloud.yaml'
+          Name: 'v1.1.8'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-ec2-windows-jumpcloud.yaml
+++ b/templates/sc-product-ec2-windows-jumpcloud.yaml
@@ -41,10 +41,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.3/ec2/sc-ec2-windows-jumpcloud.yaml'
           Name: 'v1.1.3'
-        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+        - Description: 'Use SynapseTagger'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/ec2/sc-ec2-windows-jumpcloud.yaml'
           Name: 'v1.1.7'
+        - Description: !Sub 'Add a synapse teamId tag. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.8/ec2/sc-ec2-windows-jumpcloud.yaml'
+          Name: 'v1.1.8'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/sc-product-s3-private-enc.yaml
+++ b/templates/sc-product-s3-private-enc.yaml
@@ -37,10 +37,14 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.0.1/s3/sc-s3-encrypted-ra-v1.0.1.yaml'
           Name: 'v1.0.1'
-        - Description: !Sub 'Use SynapseTagger. Last updated at ${StackDatetime}.'
+        - Description: 'Use SynapseTagger'
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.7/s3/sc-s3-encrypted-ra.yaml'
           Name: 'v1.1.7'
+        - Description: !Sub 'Add a synapse teamId tag. Last updated at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}/v1.1.8/s3/sc-s3-encrypted-ra.yaml'
+          Name: 'v1.1.8'
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:


### PR DESCRIPTION
Updte SC libraries with newer version of cfn-cr-synapse-tagger[1] to add
a Synapse teamId tag to SC resources.

[1] https://github.com/Sage-Bionetworks-IT/cfn-cr-synapse-tagger

depends on Sage-Bionetworks-IT/cfn-cr-synapse-tagger#10

also depends on creating a Sage-Bionetworks/service-catalog-library `v1.1.8` tag