### PR TITLE
Remove integration with park my cloud

### DIFF
--- a/config/develop/park-my-cloud.yaml
+++ b/config/develop/park-my-cloud.yaml
@@ -1,9 +1,0 @@
-template_path: remote/ParkMyCloud.yaml
-stack_name: park-my-cloud
-dependencies:
-  - develop/bootstrap.yaml
-parameters:
-  PMCExternalID: !ssm /infra/PMCExternalID
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml --create-dirs -o templates/remote/ParkMyCloud.yaml"

--- a/config/prod/park-my-cloud.yaml
+++ b/config/prod/park-my-cloud.yaml
@@ -1,9 +1,0 @@
-template_path: remote/ParkMyCloud.yaml
-stack_name: park-my-cloud
-dependencies:
-  - prod/bootstrap.yaml
-parameters:
-  PMCExternalID: !ssm /infra/PMCExternalID
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml --create-dirs -o templates/remote/ParkMyCloud.yaml"


### PR DESCRIPTION
We no longer use PMC to manage EC2 instances.  We now use
the SC actions feature to start/stop/restart instances.