### PR TITLE
Remove the explode macro

### DIFF
--- a/config/develop/cfn-explode-macro.yaml
+++ b/config/develop/cfn-explode-macro.yaml
@@ -1,7 +1,0 @@
-template_path: "remote/cfn-explode-macro.yaml"
-stack_name: "cfn-explode-macro"
-dependencies:
-  - "develop/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-explode-macro/master/cfn-explode-macro.yaml --create-dirs -o templates/remote/cfn-explode-macro.yaml"

--- a/config/prod/cfn-explode-macro.yaml
+++ b/config/prod/cfn-explode-macro.yaml
@@ -1,7 +1,0 @@
-template_path: "remote/cfn-explode-macro.yaml"
-stack_name: "cfn-explode-macro"
-dependencies:
-  - "prod/bootstrap.yaml"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-explode-macro/master/cfn-explode-macro.yaml --create-dirs -o templates/remote/cfn-explode-macro.yaml"


### PR DESCRIPTION
I don't remember why we needed this macro in the past but we definately
do not use it anymore.