### PR TITLE
[SC-235] Fix permission for strides account

### DIFF
--- a/config/develop/sc-enduser-iam.yaml
+++ b/config/develop/sc-enduser-iam.yaml
@@ -2,3 +2,6 @@ template_path: "sc-enduser-iam.yaml"
 stack_name: "sc-enduser-iam"
 dependencies:
   - "develop/essentials.yaml"
+parameters:
+  # InstanceRoleArn from https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/develop/templates/app.yaml
+  SynapseLoginInstanceRoleArn: !stack_output_external synapse-login-scipooldev::InstanceRoleArn

--- a/config/prod/sc-enduser-iam.yaml
+++ b/config/prod/sc-enduser-iam.yaml
@@ -2,3 +2,6 @@ template_path: "sc-enduser-iam.yaml"
 stack_name: "sc-enduser-iam"
 dependencies:
   - "prod/essentials.yaml"
+parameters:
+  # InstanceRoleArn from https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/develop/templates/app.yaml
+  SynapseLoginInstanceRoleArn: !stack_output_external synapse-login-scipoolprod::InstanceRoleArn

--- a/config/strides/sc-enduser-iam.yaml
+++ b/config/strides/sc-enduser-iam.yaml
@@ -2,3 +2,6 @@ template_path: "sc-enduser-iam.yaml"
 stack_name: "sc-enduser-iam"
 dependencies:
   - "strides/essentials.yaml"
+parameters:
+  # InstanceRoleArn from https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/develop/templates/app.yaml
+  SynapseLoginInstanceRoleArn: !stack_output_external synapse-login-strides::InstanceRoleArn

--- a/templates/sc-enduser-iam.yaml
+++ b/templates/sc-enduser-iam.yaml
@@ -19,10 +19,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: "*"
-            Condition:
-              StringLike:
-                aws:PrincipalArn: !Ref SynapseLoginInstanceRoleArn
+              AWS: !Ref SynapseLoginInstanceRoleArn
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'
@@ -41,10 +38,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: "*"
-            Condition:
-              StringLike:
-                aws:PrincipalArn: !Ref SynapseLoginInstanceRoleArn
+              AWS: !Ref SynapseLoginInstanceRoleArn
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'

--- a/templates/sc-enduser-iam.yaml
+++ b/templates/sc-enduser-iam.yaml
@@ -18,7 +18,7 @@ Resources:
               AWS: "*"
             Condition:
               StringLike:
-                aws:PrincipalArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-scipool*-InstanceRole-*'
+                aws:PrincipalArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-*-InstanceRole-*'
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'
@@ -40,7 +40,7 @@ Resources:
               AWS: "*"
             Condition:
               StringLike:
-                aws:PrincipalArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-scipool*-InstanceRole-*'
+                aws:PrincipalArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-*-InstanceRole-*'
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'

--- a/templates/sc-enduser-iam.yaml
+++ b/templates/sc-enduser-iam.yaml
@@ -1,4 +1,8 @@
 Description: "ServiceCatalog End User policy and group (fdp-1p4dlgcp7)"
+Parameters:
+  SynapseLoginInstanceRoleArn:
+    Type: String
+    Description: The Synapse login app's IAM instance role ARN
 Resources:
   SCEnduserRole:
     Type: AWS::IAM::Role
@@ -18,7 +22,7 @@ Resources:
               AWS: "*"
             Condition:
               StringLike:
-                aws:PrincipalArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-*-InstanceRole-*'
+                aws:PrincipalArn: !Ref SynapseLoginInstanceRoleArn
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'
@@ -40,7 +44,7 @@ Resources:
               AWS: "*"
             Condition:
               StringLike:
-                aws:PrincipalArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/synapse-login-*-InstanceRole-*'
+                aws:PrincipalArn: !Ref SynapseLoginInstanceRoleArn
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'


### PR DESCRIPTION
We added a `role/synapse-login-strides-InstanceRole` which doesn't match
the ServiceCatalogEndusers role regex which caused the synapse user login
to fail with the following message:

```
Error:
 com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException:
 User: arn:aws:sts::423819316185:assumed-role/synapse-login-strides-InstanceRole-NMC6P2A74X1J/i-0e2aded9709059ff3
 is not authorized to perform: sts:TagSession on resource: arn:aws:iam::423819316185:role/ServiceCatalogEndusers
 (Service: AWSSecurityTokenService; Status Code: 403; Error Code: AccessDenied; Request ID: db23c747-3cb9-4920-8d0d-93e55886357c; Proxy: null)
```

Refactor the template to pass in the exact synapse login instance role ARN instead of
using pattern matching. 

depends on Sage-Bionetworks/synapse-login-aws-infra#48