### PR TITLE
2nd attempt at DRY tag options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
   - prod
 install:
   - pip install pre-commit sceptre==2.3.0 sceptre-ssm-resolver sceptre-date-resolver awscli
+  - pip install git+git://github.com/Sage-Bionetworks-IT/sceptre-file-resolver.git
 stages:
   - name: validate
   - name: deploy-develop

--- a/config/develop/sc-tag-options-external.yaml
+++ b/config/develop/sc-tag-options-external.yaml
@@ -10,9 +10,7 @@ dependencies:
   - "develop/sc-portfolio-ec2-external.yaml"
   - "develop/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  Departments:
-    - "sage-external"
-  Projects:
-    - "collaborator"
+  Departments: !file sc-tag-options/external/Departments.json
+  Projects: !file sc-tag-options/external/Projects.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/config/develop/sc-tag-options.yaml
+++ b/config/develop/sc-tag-options.yaml
@@ -10,29 +10,8 @@ dependencies:
   - "develop/sc-portfolio-ec2-external.yaml"
   - "develop/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  Departments:
-    - "CompOnc"
-    - "Governance"
-    - "NDR"
-    - "Platform"
-    - "SysBio"
-  Projects:
-    - "amp-ad"
-    - "ACT"
-    - "challenge"  # Sometimes challenges aren't always DREAM
-    - "csbs"
-    - "dream"
-    - "dream/metadata"
-    - "genie"
-    - "htan"
-    - "iAtlas"
-    - "imCORE"
-    - "Infrastructure"
-    - "neurofibromatosis"
-    - "pson"
-    - "PsychENCODE"
-    - "TESLA"
-    - "veo-ibd"
+  Departments: !file sc-tag-options/internal/Departments.json
+  Projects: !file sc-tag-options/internal/Projects.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/config/prod/sc-tag-options-external.yaml
+++ b/config/prod/sc-tag-options-external.yaml
@@ -10,9 +10,7 @@ dependencies:
   - "prod/sc-portfolio-ec2-external.yaml"
   - "prod/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  Departments:
-    - "sage-external"
-  Projects:
-    - "collaborator"
+  Departments: !file sc-tag-options/external/Departments.json
+  Projects: !file sc-tag-options/external/Projects.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/config/prod/sc-tag-options.yaml
+++ b/config/prod/sc-tag-options.yaml
@@ -10,29 +10,8 @@ dependencies:
   - "prod/sc-portfolio-ec2-external.yaml"
   - "prod/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  Departments:
-    - "CompOnc"
-    - "Governance"
-    - "NDR"
-    - "Platform"
-    - "SysBio"
-  Projects:
-    - "amp-ad"
-    - "ACT"
-    - "challenge"  # Sometimes challenges aren't always DREAM
-    - "csbs"
-    - "dream"
-    - "dream/metadata"
-    - "genie"
-    - "htan"
-    - "iAtlas"
-    - "imCORE"
-    - "Infrastructure"
-    - "neurofibromatosis"
-    - "pson"
-    - "PsychENCODE"
-    - "TESLA"
-    - "veo-ibd"
+  Departments: !file sc-tag-options/internal/Departments.json
+  Projects: !file sc-tag-options/internal/Projects.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/config/strides/sc-tag-options-external.yaml
+++ b/config/strides/sc-tag-options-external.yaml
@@ -10,9 +10,14 @@ dependencies:
   - "strides/sc-portfolio-ec2-external.yaml"
   - "strides/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
+<<<<<<< HEAD
   Departments:
     - "sage-external"
   Projects:
     - "collaborator"
+=======
+  Departments: !file sc-tag-options/external/Departments.json
+  Projects: !file sc-tag-options/external/Projects.json
+>>>>>>> aac298c... 2nd attempt at DRY tag options
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/config/strides/sc-tag-options-external.yaml
+++ b/config/strides/sc-tag-options-external.yaml
@@ -10,14 +10,7 @@ dependencies:
   - "strides/sc-portfolio-ec2-external.yaml"
   - "strides/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-<<<<<<< HEAD
-  Departments:
-    - "sage-external"
-  Projects:
-    - "collaborator"
-=======
   Departments: !file sc-tag-options/external/Departments.json
   Projects: !file sc-tag-options/external/Projects.json
->>>>>>> aac298c... 2nd attempt at DRY tag options
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2-external::SCEC2portfolioId

--- a/config/strides/sc-tag-options.yaml
+++ b/config/strides/sc-tag-options.yaml
@@ -10,29 +10,8 @@ dependencies:
   - "strides/sc-portfolio-ec2-external.yaml"
   - "strides/sc-portfolio-s3-basic.yaml"
 sceptre_user_data:
-  Departments:
-    - "CompOnc"
-    - "Governance"
-    - "NDR"
-    - "Platform"
-    - "SysBio"
-  Projects:
-    - "amp-ad"
-    - "ACT"
-    - "challenge"  # Sometimes challenges aren't always DREAM
-    - "csbs"
-    - "dream"
-    - "dream/metadata"
-    - "genie"
-    - "htan"
-    - "iAtlas"
-    - "imCORE"
-    - "Infrastructure"
-    - "neurofibromatosis"
-    - "pson"
-    - "PsychENCODE"
-    - "TESLA"
-    - "veo-ibd"
+  Departments: !file sc-tag-options/internal/Departments.json
+  Projects: !file sc-tag-options/internal/Projects.json
   ProductIDs:
     - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
     - !stack_output_external sc-portfolio-s3-basic::SCS3portfolioId

--- a/sc-tag-options/external/Departments.json
+++ b/sc-tag-options/external/Departments.json
@@ -1,0 +1,3 @@
+[
+  "sage-external"
+]

--- a/sc-tag-options/external/Projects.json
+++ b/sc-tag-options/external/Projects.json
@@ -1,0 +1,3 @@
+[
+  "collaborator"
+]

--- a/sc-tag-options/internal/Departments.json
+++ b/sc-tag-options/internal/Departments.json
@@ -1,0 +1,7 @@
+[
+  "CompOnc",
+  "Governance",
+  "NDR",
+  "Platform",
+  "SysBio"
+]

--- a/sc-tag-options/internal/Projects.json
+++ b/sc-tag-options/internal/Projects.json
@@ -1,0 +1,18 @@
+[
+  "amp-ad",
+  "ACT",
+  "challenge",
+  "csbs",
+  "dream",
+  "dream/metadata",
+  "genie",
+  "htan",
+  "iAtlas",
+  "imCORE",
+  "Infrastructure",
+  "neurofibromatosis",
+  "pson",
+  "PsychENCODE",
+  "TESLA",
+  "veo-ibd"
+]


### PR DESCRIPTION
This is a 2nd attempt at commit a7f72bd6b3. The first attempt failed
because using the Sceptre file_contents resolver[1] passed the file
content as a string to the parameter. The jinja template that processes
the parameter requires a list object.  The new and improved
Sceptre file resolver[2] fixes this by getting the contents of a json or
yaml file and passing it to the parameter as an object.

[1] https://sceptre.cloudreach.com/2.2.1/docs/resolvers.html#file-contents
[2] https://github.com/Sage-Bionetworks-IT/sceptre-file-resolver

depends on https://github.com/Sage-Bionetworks-IT/sceptre-file-resolver/pull/1