### PR TITLE
[SC-255] output the marketplace dynamodb table ARN

### DIFF
--- a/templates/marketplace-dynamo.yaml
+++ b/templates/marketplace-dynamo.yaml
@@ -44,3 +44,8 @@ Outputs:
     Value: !Ref DynamoDBTable
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-MarketplaceDynamoDBTable'
+  MarketplaceDynamoTableArn:
+    Description: 'DynamoDB Table ARN for Marketplace registration information'
+    Value: !GetAtt DynamoDBTable.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-MarketplaceDynamoDBTableArn'


### PR DESCRIPTION
The dyamodb table ARN is needed by the cfn-cr-synapse-tagger in PR https://github.com/Sage-Bionetworks-IT/cfn-cr-synapse-tagger/pull/19