### PR TITLE
SC-254:  Managed policy uses 'friendly name' for Role, not Role ARN

### DIFF
--- a/config/develop/idp-marketplace-policy.yaml
+++ b/config/develop/idp-marketplace-policy.yaml
@@ -5,4 +5,4 @@ dependencies:
   - "develop/synapse-oidc-idp.yaml"
 parameters:
   # InstanceRoleArn from https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/develop/templates/app.yaml
-  SynapseLoginInstanceRoleArn: !stack_output_external synapse-login-scipooldev::InstanceRoleArn
+  SynapseLoginInstanceRole: !stack_output_external synapse-login-scipooldev::InstanceRole

--- a/config/develop/marketplace-dynamo.yaml
+++ b/config/develop/marketplace-dynamo.yaml
@@ -5,4 +5,4 @@ dependencies:
   - "develop/synapse-oidc-idp.yaml"
 parameters:
   # InstanceRoleArn from https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/develop/templates/app.yaml
-  SynapseLoginInstanceRoleArn: !stack_output_external synapse-login-scipooldev::InstanceRoleArn
+  SynapseLoginInstanceRole: !stack_output_external synapse-login-scipooldev::InstanceRole

--- a/config/prod/idp-marketplace-policy.yaml
+++ b/config/prod/idp-marketplace-policy.yaml
@@ -5,4 +5,4 @@ dependencies:
   - "prod/synapse-oidc-idp.yaml"
 parameters:
   # InstanceRoleArn from https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/prod/templates/app.yaml
-  SynapseLoginInstanceRoleArn: !stack_output_external synapse-login-scipoolprod::InstanceRoleArn
+  SynapseLoginInstanceRole: !stack_output_external synapse-login-scipoolprod::InstanceRole

--- a/config/prod/marketplace-dynamo.yaml
+++ b/config/prod/marketplace-dynamo.yaml
@@ -5,4 +5,4 @@ dependencies:
   - "prod/synapse-oidc-idp.yaml"
 parameters:
   # InstanceRoleArn from https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/prod/templates/app.yaml
-  SynapseLoginInstanceRoleArn: !stack_output_external synapse-login-scipoolprod::InstanceRoleArn
+  SynapseLoginInstanceRole: !stack_output_external synapse-login-scipoolprod::InstanceRole

--- a/config/strides/idp-marketplace-policy.yaml
+++ b/config/strides/idp-marketplace-policy.yaml
@@ -5,4 +5,4 @@ dependencies:
   - "strides/synapse-oidc-idp.yaml"
 parameters:
   # InstanceRoleArn from https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/strides/templates/app.yaml
-  SynapseLoginInstanceRoleArn: !stack_output_external synapse-login-strides::InstanceRoleArn
+  SynapseLoginInstanceRole: !stack_output_external synapse-login-strides::InstanceRole

--- a/config/strides/marketplace-dynamo.yaml
+++ b/config/strides/marketplace-dynamo.yaml
@@ -5,4 +5,4 @@ dependencies:
   - "strides/synapse-oidc-idp.yaml"
 parameters:
   # InstanceRoleArn from https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/strides/templates/app.yaml
-  SynapseLoginInstanceRoleArn: !stack_output_external synapse-login-strides::InstanceRoleArn
+  SynapseLoginInstanceRole: !stack_output_external synapse-login-strides::InstanceRole

--- a/templates/idp-marketplace-policy.yaml
+++ b/templates/idp-marketplace-policy.yaml
@@ -18,4 +18,4 @@ Resources:
             Resource: "*"
 
       Roles:
-        - !Ref SynapseLoginInstanceRoleArn
+        - !Ref SynapseLoginInstanceRole

--- a/templates/idp-marketplace-policy.yaml
+++ b/templates/idp-marketplace-policy.yaml
@@ -1,8 +1,8 @@
 Description: "Policy that lets the Synapse login role resolve marketplace customer"
 Parameters:
-  SynapseLoginInstanceRoleArn:
+  SynapseLoginInstanceRole:
     Type: String
-    Description: The Synapse login app's IAM instance role ARN
+    Description: The Synapse login app's IAM instance role name
 
 Resources:
   ResolveCustomerMarketplacePolicy:

--- a/templates/marketplace-dynamo.yaml
+++ b/templates/marketplace-dynamo.yaml
@@ -2,7 +2,7 @@ Description: Set up DynamoDB for AWS Marketplace registration
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
-  SynapseLoginInstanceRoleArn:
+  SynapseLoginInstanceRole:
     Type: String
     Description: The Synapse login app's IAM instance role ARN
 

--- a/templates/marketplace-dynamo.yaml
+++ b/templates/marketplace-dynamo.yaml
@@ -36,7 +36,7 @@ Resources:
               - 'dynamodb:*Put*'
             Resource: !GetAtt DynamoDBTable.Arn
       Roles:
-        - !Ref SynapseLoginInstanceRoleArn
+        - !Ref SynapseLoginInstanceRole
 
 Outputs:
   MarketplaceDynamoTable:


### PR DESCRIPTION
The build broke:
https://travis-ci.org/github/Sage-Bionetworks/scipool-infra/jobs/739142121

and I traced it to the [definition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html) of the Roles field in a managed policy declaration:  The Roles field is "The name (friendly name, not ARN) of the role to attach the policy to."

[synapse-login-aws-infra](https://github.com/Sage-Bionetworks/synapse-login-aws-infra/blob/develop/templates/app.yaml) exports both InstanceRole.Arn and InstanceRole. I am *assuming* that "InstanceRole" is the requisite "friendly name".