### PR TITLE
remove cfn-cr-bucket-tagger

### DIFF
--- a/config/develop/cfn-cr-bucket-tagger.yaml
+++ b/config/develop/cfn-cr-bucket-tagger.yaml
@@ -1,9 +1,0 @@
-template_path: remote/cfn-cr-bucket-tagger.yaml
-stack_name: cfn-cr-bucket-tagger
-stack_tags:
-  Department: "Platform"
-  Project: "Infrastructure"
-  OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-bucket-tagger/master/cfn-cr-bucket-tagger.yaml --create-dirs -o templates/remote/cfn-cr-bucket-tagger.yaml"

--- a/config/prod/cfn-cr-bucket-tagger.yaml
+++ b/config/prod/cfn-cr-bucket-tagger.yaml
@@ -1,9 +1,0 @@
-template_path: remote/cfn-cr-bucket-tagger.yaml
-stack_name: cfn-cr-bucket-tagger
-stack_tags:
-  Department: "Platform"
-  Project: "Infrastructure"
-  OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-bucket-tagger/master/cfn-cr-bucket-tagger.yaml --create-dirs -o templates/remote/cfn-cr-bucket-tagger.yaml"

--- a/config/strides/cfn-cr-bucket-tagger.yaml
+++ b/config/strides/cfn-cr-bucket-tagger.yaml
@@ -1,9 +1,0 @@
-template_path: remote/cfn-cr-bucket-tagger.yaml
-stack_name: cfn-cr-bucket-tagger
-stack_tags:
-  Department: "Platform"
-  Project: "Infrastructure"
-  OwnerEmail: "it@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-bucket-tagger/master/cfn-cr-bucket-tagger.yaml --create-dirs -o templates/remote/cfn-cr-bucket-tagger.yaml"


### PR DESCRIPTION
The cfn-cr-bucket-tagger is deprecated and has been replaced with
the cfn-cr-synapse-tagger