### PR TITLE
Add standard SSL policy

### DIFF
--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -44,7 +44,7 @@ Resources:
         Ref: ApplicationLoadBalancer
       Certificates:
         - CertificateArn: !Ref SSLCertificateArn
-      SslPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
+      SslPolicy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
       DefaultActions:
         - Type: redirect
           Order: 50000

--- a/templates/alb-notebook-access.yaml
+++ b/templates/alb-notebook-access.yaml
@@ -44,6 +44,7 @@ Resources:
         Ref: ApplicationLoadBalancer
       Certificates:
         - CertificateArn: !Ref SSLCertificateArn
+      SslPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
       DefaultActions:
         - Type: redirect
           Order: 50000


### PR DESCRIPTION
This adds an SSL policy beyond the default to the notebook ALB and will not require replacement. 

It passes pre-commit, but I'm not able to validate the template or push it to a test env. 
